### PR TITLE
[WIP] User preferences

### DIFF
--- a/app/controllers/archangel/backend/profiles_controller.rb
+++ b/app/controllers/archangel/backend/profiles_controller.rb
@@ -173,7 +173,8 @@ module Archangel
       protected
 
       def permitted_attributes
-        %w[avatar email name password remove_avatar username]
+        %w[avatar email name password remove_avatar username
+           newsletter]
       end
 
       def resource_content

--- a/app/models/archangel/user.rb
+++ b/app/models/archangel/user.rb
@@ -9,6 +9,11 @@ module Archangel
 
     mount_uploader :avatar, Archangel::AvatarUploader
 
+    typed_store :preferences, coder: JSON do |s|
+      s.boolean :newsletter, default: false
+      s.datetime :prefered_at, default: Time.now
+    end
+
     before_validation :parameterize_username
 
     after_initialize :column_default
@@ -30,6 +35,8 @@ module Archangel
     validates :password, allow_blank: true, length: { minimum: 8 }, on: :update
     validates :role, presence: true, inclusion: { in: Archangel::ROLES }
     validates :username, presence: true, uniqueness: { scope: :site_id }
+
+    validates :newsletter, inclusion: { in: [true, false] }
 
     belongs_to :site
 

--- a/app/models/archangel/user.rb
+++ b/app/models/archangel/user.rb
@@ -11,7 +11,7 @@ module Archangel
 
     typed_store :preferences, coder: JSON do |s|
       s.boolean :newsletter, default: false
-      s.datetime :prefered_at, default: Time.now
+      s.datetime :preferred_at, default: Time.now
     end
 
     before_validation :parameterize_username

--- a/app/views/archangel/backend/profiles/_form.html.erb
+++ b/app/views/archangel/backend/profiles/_form.html.erb
@@ -23,6 +23,8 @@
 
     <%= f.input :password, as: :password %>
     <%= f.input :password_confirmation, as: :password %>
+
+    <%= f.input :newsletter, as: :boolean, inline_label: Archangel.t(:subscribe_to_newsletter) %>
   </div>
 
   <div class="form-actions text-right">

--- a/archangel.gemspec
+++ b/archangel.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_dependency "thor", "~> 0.19", ">= 0.19.0"
   s.add_dependency "uglifier", "~> 4.1", ">= 4.1.8"
 
+  s.add_dependency "activerecord-typedstore", "~> 1.2"
   s.add_dependency "acts_as_list", "~> 0.9"
   s.add_dependency "acts_as_tree", "~> 2.8"
   s.add_dependency "anyway_config", "~> 1.3"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,6 +114,7 @@ en:
     sort: Sort
     sortable:
       success: Sort order has been updated
+    subscribe_to_newsletter: Subscribe to newsletter
     templates: Templates
     theme: Theme
     title: Title

--- a/db/migrate/20190101220919_add_preferences_to_archangel_users.rb
+++ b/db/migrate/20190101220919_add_preferences_to_archangel_users.rb
@@ -1,0 +1,5 @@
+class AddPreferencesToArchangelUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :archangel_users, :preferences, :text
+  end
+end

--- a/lib/archangel.rb
+++ b/lib/archangel.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "activerecord-typedstore"
 require "acts_as_list"
 require "acts_as_tree"
 require "anyway_config"


### PR DESCRIPTION
# Summary

Start on User preferences. This same concept will also be used later for Site setting and Page settings. Right now the only preference is `newsletter` (boolean).

## What's New

* Add `activerecord-typedstore` dependency
* Add a migration to create `archangel_users.preferences` (text) to store User preferences
* Add `newsletter` (boolean) preference as an example preference
* Add `preferred_at` (datetime) preference to should stand as a timestamp of when the preference object was first created

## What's Changed

Nothing