### PR TITLE
Fix User registration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gemspec
 
 group :development do
   gem "brakeman", "~> 4.3", require: false
-  gem "bundler-audit", "~> 0.6", require: false
   gem "inch", "~> 0.8", require: false
   gem "listen", "~> 3.1", require: false
   gem "mdl", "~> 0.5", require: false

--- a/app/controllers/archangel/auth/registrations_controller.rb
+++ b/app/controllers/archangel/auth/registrations_controller.rb
@@ -14,6 +14,10 @@ module Archangel
 
       protected
 
+      def sign_up_params
+        super.merge(site_id: current_site.id)
+      end
+
       def allow_registration
         return render_404_error unless Archangel.config.allow_registration
       end

--- a/app/controllers/archangel/auth/registrations_controller.rb
+++ b/app/controllers/archangel/auth/registrations_controller.rb
@@ -14,6 +14,14 @@ module Archangel
 
       protected
 
+      def after_sign_up_path_for(resource)
+        stored_location_for(resource) || root_path
+      end
+
+      def after_inactive_sign_up_path_for(resource)
+        after_sign_up_path_for(resource)
+      end
+
       def sign_up_params
         super.merge(site_id: current_site.id)
       end

--- a/archangel.gemspec
+++ b/archangel.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activerecord-typedstore", "~> 1.2"
   s.add_dependency "acts_as_list", "~> 0.9"
   s.add_dependency "acts_as_tree", "~> 2.8"
-  s.add_dependency "anyway_config", "~> 1.3"
+  s.add_dependency "anyway_config", "~> 1.4"
   s.add_dependency "bootstrap", "~> 4.1"
   s.add_dependency "carrierwave", "~> 1.2"
   s.add_dependency "cocoon", "~> 1.2"

--- a/lib/archangel/config.rb
+++ b/lib/archangel/config.rb
@@ -9,11 +9,11 @@ module Archangel
 
     attr_config allow_registration: false,
                 asset_maximum_file_size: 2.megabytes,
-                asset_extension_whitelist: %i[gif jpeg jpg png],
+                asset_extension_whitelist: %w[gif jpeg jpg png],
                 auth_path: "account",
                 backend_path: "backend",
                 frontend_path: "",
-                image_extension_whitelist: %i[gif jpeg jpg png],
+                image_extension_whitelist: %w[gif jpeg jpg png],
                 image_maximum_file_size: 2.megabytes
 
     def keys_in(keys)

--- a/lib/generators/archangel/install/templates/config/archangel.yml
+++ b/lib/generators/archangel/install/templates/config/archangel.yml
@@ -28,21 +28,6 @@ default: &default
   #
   asset_maximum_file_size: <%= 1024 * 1024 * 2 %>
 
-  # File extension whitelist of favicon uploads.
-  # Default is ['gif', 'ico', 'jpeg', 'jpg', 'png']
-  #
-  favicon_extension_whitelist:
-    - gif
-    - ico
-    - jpeg
-    - jpg
-    - png
-
-  # Maximum file size of for favicon uploads.
-  # Default is `2097152` (2 Mb) (1024 b * 1024 Kb * 2 Mb)
-  #
-  favicon_maximum_file_size: <%= 1024 * 1024 * 2 %>
-
   # File extension whitelist of general image uploads.
   # Default is ['gif', 'jpeg', 'jpg', 'png']
   #

--- a/lib/generators/archangel/install/templates/config/archangel.yml
+++ b/lib/generators/archangel/install/templates/config/archangel.yml
@@ -24,9 +24,9 @@ default: &default
     - png
 
   # Maximum file size of for asset uploads.
-  # Default is `2000000` (2 Mb)
+  # Default is `2097152` (2 Mb) (1024 b * 1024 Kb * 2 Mb)
   #
-  asset_maximum_file_size: 2000000
+  asset_maximum_file_size: <%= 1024 * 1024 * 2 %>
 
   # File extension whitelist of favicon uploads.
   # Default is ['gif', 'ico', 'jpeg', 'jpg', 'png']
@@ -39,9 +39,9 @@ default: &default
     - png
 
   # Maximum file size of for favicon uploads.
-  # Default is `2000000` (2 Mb)
+  # Default is `2097152` (2 Mb) (1024 b * 1024 Kb * 2 Mb)
   #
-  favicon_maximum_file_size: 2000000
+  favicon_maximum_file_size: <%= 1024 * 1024 * 2 %>
 
   # File extension whitelist of general image uploads.
   # Default is ['gif', 'jpeg', 'jpg', 'png']
@@ -53,9 +53,9 @@ default: &default
     - png
 
   # Maximum file size of for general image uploads.
-  # Default is `2000000` (2 Mb)
+  # # Default is `2097152` (2 Mb) (1024 b * 1024 Kb * 2 Mb)
   #
-  image_maximum_file_size: 2000000
+  image_maximum_file_size: <%= 1024 * 1024 * 2 %>
 
 development:
   <<: *default

--- a/lib/generators/archangel/install/templates/config/archangel.yml
+++ b/lib/generators/archangel/install/templates/config/archangel.yml
@@ -1,37 +1,67 @@
-# Auth root path.
-# Default is "account"
-#
-auth_path: "account"
+default: &default
+  # Auth root path.
+  # Default is "account"
+  #
+  auth_path: "account"
 
-# Backend root path.
-# Default is "backend"
-#
-backend_path: "backend"
+  # Allow user registrations.
+  # Default is `false`
+  #
+  allow_registration: false
 
-# File extension whitelist of asset uploads.
-# Default is ['gif', 'jpeg', 'jpg', 'png']
-#
-asset_extension_whitelist:
-  - gif
-  - jpeg
-  - jpg
-  - png
+  # Backend root path.
+  # Default is "backend"
+  #
+  backend_path: "backend"
 
-# Maximum file size of for asset uploads.
-# Default is `2.megabytes`
-#
-asset_maximum_file_size: 2.megabytes
+  # File extension whitelist of asset uploads.
+  # Default is ['gif', 'jpeg', 'jpg', 'png']
+  #
+  asset_extension_whitelist:
+    - gif
+    - jpeg
+    - jpg
+    - png
 
-# File extension whitelist of general image uploads.
-# Default is ['gif', 'jpeg', 'jpg', 'png']
-#
-image_extension_whitelist:
-  - gif
-  - jpeg
-  - jpg
-  - png
+  # Maximum file size of for asset uploads.
+  # Default is `2000000` (2 Mb)
+  #
+  asset_maximum_file_size: 2000000
 
-# Maximum file size of for general image uploads.
-# Default is `2.megabytes`
-#
-image_maximum_file_size: 2.megabytes
+  # File extension whitelist of favicon uploads.
+  # Default is ['gif', 'ico', 'jpeg', 'jpg', 'png']
+  #
+  favicon_extension_whitelist:
+    - gif
+    - ico
+    - jpeg
+    - jpg
+    - png
+
+  # Maximum file size of for favicon uploads.
+  # Default is `2000000` (2 Mb)
+  #
+  favicon_maximum_file_size: 2000000
+
+  # File extension whitelist of general image uploads.
+  # Default is ['gif', 'jpeg', 'jpg', 'png']
+  #
+  image_extension_whitelist:
+    - gif
+    - jpeg
+    - jpg
+    - png
+
+  # Maximum file size of for general image uploads.
+  # Default is `2000000` (2 Mb)
+  #
+  image_maximum_file_size: 2000000
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/spec/features/auth/registration_spec.rb
+++ b/spec/features/auth/registration_spec.rb
@@ -29,9 +29,7 @@ RSpec.feature "Auth registration", type: :feature do
 
       create(:page, homepage: true, content: "Welcome to the homepage")
 
-      visit archangel.backend_root_path
-
-      click_link "Sign up"
+      visit archangel.new_user_registration_path
 
       fill_in "Name", with: "John Doe"
       fill_in "Username", with: "john_doe"

--- a/spec/features/auth/registration_spec.rb
+++ b/spec/features/auth/registration_spec.rb
@@ -23,5 +23,25 @@ RSpec.feature "Auth registration", type: :feature do
       expect(page).to have_selector("input[type=text][id='user_name']")
       expect(page).to have_selector("input[type=text][id='user_username']")
     end
+
+    it "allows successful registration" do
+      allow(Archangel.config).to receive(:allow_registration) { true }
+
+      create(:page, homepage: true, content: "Welcome to the homepage")
+
+      visit archangel.backend_root_path
+
+      click_link "Sign up"
+
+      fill_in "Name", with: "John Doe"
+      fill_in "Username", with: "john_doe"
+      fill_in "Email", with: "me@example.com"
+      fill_in "Password", with: "password"
+      fill_in "Confirm Password", with: "password"
+
+      click_button "Sign up"
+
+      expect(page).to have_content("Welcome to the homepage")
+    end
   end
 end

--- a/spec/uploaders/archangel/application_uploader_spec.rb
+++ b/spec/uploaders/archangel/application_uploader_spec.rb
@@ -9,7 +9,7 @@ module Archangel
     end
 
     it "allows certain extensions" do
-      expect(subject.extension_whitelist).to eq %i[gif jpeg jpg png]
+      expect(subject.extension_whitelist).to eq %w[gif jpeg jpg png]
     end
   end
 end

--- a/spec/uploaders/archangel/asset_uploader_spec.rb
+++ b/spec/uploaders/archangel/asset_uploader_spec.rb
@@ -12,7 +12,7 @@ module Archangel
     end
 
     it "allows certain extensions" do
-      expect(subject.extension_whitelist).to eq %i[gif jpeg jpg png]
+      expect(subject.extension_whitelist).to eq %w[gif jpeg jpg png]
     end
 
     context "with image file" do


### PR DESCRIPTION
# Summary

I had AnywayConfig set up wrong so it wasn't actually taking the settings from the .yml file. Corrected that issue. This also fixes registration where an error was thrown because `site_id` field was required but not provided.

## What's New

Nothing

## What's Changed

* Inject `site_id` into Devise on User registration since it is a required field
* Format `config/archangel.yml` correctly to split for environment
* Bump `anyway_config` version dependency
* Remove `bundler-audit` dependency