### PR TITLE
Rebuild Metatags

### DIFF
--- a/app/controllers/archangel/application_controller.rb
+++ b/app/controllers/archangel/application_controller.rb
@@ -54,8 +54,6 @@ module Archangel
     #     },
     #     "content": "</p>Content of the Widget</p>",
     #     "template_id": 123,
-    #     "meta_keywords": "keywords,for,the,site",
-    #     "meta_description": "Description of the site",
     #     "deleted_at": null,
     #     "created_at": "YYYY-MM-DDTHH:MM:SS.MSZ",
     #     "updated_at": "YYYY-MM-DDTHH:MM:SS.MSZ"

--- a/app/controllers/archangel/backend/pages_controller.rb
+++ b/app/controllers/archangel/backend/pages_controller.rb
@@ -14,8 +14,7 @@ module Archangel
       protected
 
       def permitted_attributes
-        %w[content homepage meta_description meta_keywords parent_id path
-           published_at slug template_id title]
+        %w[content homepage parent_id path published_at slug template_id title]
       end
 
       def resources_content

--- a/app/controllers/archangel/backend/pages_controller.rb
+++ b/app/controllers/archangel/backend/pages_controller.rb
@@ -14,7 +14,11 @@ module Archangel
       protected
 
       def permitted_attributes
-        %w[content homepage parent_id path published_at slug template_id title]
+        [
+          :content, :homepage, :parent_id, :path, :published_at, :slug,
+          :template_id, :title,
+          metatags_attributes: %i[id _destroy name content]
+        ]
       end
 
       def resources_content
@@ -35,6 +39,8 @@ module Archangel
 
       def resource_new_content
         @page = current_site.pages.new(resource_new_params)
+
+        @page.metatags.build unless @page.metatags.present?
 
         authorize @page
       end

--- a/app/controllers/archangel/backend/sites_controller.rb
+++ b/app/controllers/archangel/backend/sites_controller.rb
@@ -42,8 +42,6 @@ module Archangel
       #     },
       #     "content": "</p>Content of the Widget</p>",
       #     "template_id": 123,
-      #     "meta_keywords": "keywords,for,the,site",
-      #     "meta_description": "Description of the site",
       #     "deleted_at": null,
       #     "created_at": "YYYY-MM-DDTHH:MM:SS.MSZ",
       #     "updated_at": "YYYY-MM-DDTHH:MM:SS.MSZ"
@@ -87,9 +85,7 @@ module Archangel
       #       }
       #     },
       #     "content": "</p>Content of the Widget</p>",
-      #     "template_id": 123,
-      #     "meta_keywords": "keywords,for,the,site",
-      #     "meta_description": "Description of the site"
+      #     "template_id": 123
       #   }
       #
       def edit
@@ -132,9 +128,7 @@ module Archangel
       #         }
       #       },
       #       "content": "</p>Content of the Widget</p>",
-      #       "template_id": 123,
-      #       "meta_keywords": "keywords,for,the,site",
-      #       "meta_description": "Description of the site"
+      #       "template_id": 123
       #     }
       #   }
       #
@@ -149,7 +143,7 @@ module Archangel
       protected
 
       def permitted_attributes
-        %w[locale logo meta_description meta_keywords name remove_logo theme]
+        %w[locale logo name remove_logo theme]
       end
 
       def resource_content

--- a/app/controllers/archangel/backend/sites_controller.rb
+++ b/app/controllers/archangel/backend/sites_controller.rb
@@ -143,7 +143,10 @@ module Archangel
       protected
 
       def permitted_attributes
-        %w[locale logo name remove_logo theme]
+        [
+          :locale, :logo, :name, :remove_logo, :theme,
+          metatags_attributes: %i[id _destroy name content]
+        ]
       end
 
       def resource_content

--- a/app/controllers/archangel/frontend/pages_controller.rb
+++ b/app/controllers/archangel/frontend/pages_controller.rb
@@ -78,9 +78,12 @@ module Archangel
       # @return [Object] the page meta tags
       #
       def page_meta_tags
-        {
-          title: @page.title
-        }
+        [
+          current_site.metatags,
+          @page.metatags
+        ].flatten.inject({}) do |tags, metatag|
+          tags.merge(metatag.name => metatag.content)
+        end.merge(title: @page.title)
       end
 
       ##

--- a/app/controllers/archangel/frontend/pages_controller.rb
+++ b/app/controllers/archangel/frontend/pages_controller.rb
@@ -33,8 +33,6 @@ module Archangel
       #     "path": "path/to/page",
       #     "content": "</p>Content of the page</p>",
       #     "homepage": false,
-      #     "meta_keywords": "keywords, for, the, page",
-      #     "meta_description": "Description of the page",
       #     "published_at": "YYYY-MM-DDTHH:MM:SS.MSZ",
       #     "created_at": "YYYY-MM-DDTHH:MM:SS.MSZ",
       #     "updated_at": "YYYY-MM-DDTHH:MM:SS.MSZ",
@@ -81,9 +79,7 @@ module Archangel
       #
       def page_meta_tags
         {
-          title: @page.title,
-          description: @page.meta_description,
-          keywords: @page.meta_keywords.to_s.split(",")
+          title: @page.title
         }
       end
 

--- a/app/controllers/concerns/archangel/actionable_concern.rb
+++ b/app/controllers/concerns/archangel/actionable_concern.rb
@@ -23,6 +23,7 @@ module Archangel
     # Controller action name as a symbol
     #
     # @return [Symbol] the action name
+    #
     def action
       action_name.to_sym
     end
@@ -34,6 +35,7 @@ module Archangel
     # Collection actions can be modified by overwriting `#collection_actions`
     #
     # @return [Boolean] if action is a collection action
+    #
     def collection_action?
       collection_actions.include?(action)
     end
@@ -45,6 +47,7 @@ module Archangel
     # Edit actions can be modified by overwriting `#edit_actions`
     #
     # @return [Boolean] if action is an edit action
+    #
     def edit_action?
       edit_actions.include?(action)
     end
@@ -52,6 +55,7 @@ module Archangel
     # Test if action is the `index` action
     #
     # @return [Boolean] if action is the index action
+    #
     def index_action?
       action?(:index)
     end
@@ -63,6 +67,7 @@ module Archangel
     # Member actions can be modified by overwriting `#member_actions`
     #
     # @return [Boolean] if action is an edit action
+    #
     def member_action?
       member_actions.include?(action)
     end
@@ -74,6 +79,7 @@ module Archangel
     # New actions can be modified by overwriting `#new_actions`
     #
     # @return [Boolean] if action is an edit action
+    #
     def new_action?
       new_actions.include?(action)
     end
@@ -85,6 +91,7 @@ module Archangel
     # RESTful actions can be modified by overwriting `#restful_actions`
     #
     # @return [Boolean] if action is an edit action
+    #
     def restful_action?
       restful_actions.include?(action)
     end
@@ -96,6 +103,7 @@ module Archangel
     # Save actions can be modified by overwriting `#save_actions`
     #
     # @return [Boolean] if action is an edit action
+    #
     def save_action?
       save_actions.include?(action)
     end
@@ -107,6 +115,7 @@ module Archangel
     # Show actions can be modified by overwriting `#show_actions`
     #
     # @return [Boolean] if action is a show action
+    #
     def show_action?
       show_actions.include?(action)
     end

--- a/app/controllers/concerns/archangel/paginatable_concern.rb
+++ b/app/controllers/concerns/archangel/paginatable_concern.rb
@@ -14,6 +14,7 @@ module Archangel
     # Record limt count
     #
     # @return [Integer] the record count limit
+    #
     def per_page
       params.fetch(:per, per_page_default).to_i
     end
@@ -21,6 +22,7 @@ module Archangel
     # Current page number
     #
     # @return [Integer] the page number
+    #
     def page_num
       params.fetch(Kaminari.config.param_name, 1).to_i
     end

--- a/app/controllers/concerns/archangel/seoable_concern.rb
+++ b/app/controllers/concerns/archangel/seoable_concern.rb
@@ -15,6 +15,7 @@ module Archangel
     # Set meta tags
     #
     # @param meta_tags [Hash] list of meta tags
+    #
     def apply_meta_tags(meta_tags = {})
       meta = meta_tags.reject { |_name, value| value.blank? }
 
@@ -29,12 +30,10 @@ module Archangel
 
     def default_meta_tags
       {
-        reverse:     true,
-        site:        current_site.name,
-        canonical:   request.url,
-        image_src:   current_site.logo.url,
-        description: current_site.meta_description,
-        keywords:    current_site.meta_keywords.to_s.split(",")
+        reverse: true,
+        site: current_site.name,
+        canonical: request.url,
+        image_src: current_site.logo.url
       }
     end
   end

--- a/app/models/archangel/metatag.rb
+++ b/app/models/archangel/metatag.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Archangel
+  ##
+  # Metatag model
+  #
+  class Metatag < ApplicationRecord
+    validates :name, uniqueness: { scope: %i[metatagable_type metatagable_id] }
+
+    belongs_to :metatagable, polymorphic: true
+  end
+end

--- a/app/models/archangel/page.rb
+++ b/app/models/archangel/page.rb
@@ -33,6 +33,11 @@ module Archangel
     belongs_to :site
     belongs_to :template, -> { where(partial: false) }, optional: true
 
+    has_many :metatags, as: :metatagable
+
+    accepts_nested_attributes_for :metatags, reject_if: :all_blank,
+                                             allow_destroy: true
+
     scope :published, (lambda do
       where.not(published_at: nil).where("published_at <= ?", Time.now)
     end)

--- a/app/models/archangel/site.rb
+++ b/app/models/archangel/site.rb
@@ -17,14 +17,19 @@ module Archangel
     validates :theme, inclusion: { in: Archangel.themes }, allow_blank: true
 
     has_many :assets
+    has_many :collections
     has_many :pages
     has_many :templates
     has_many :users
     has_many :widgets
 
-    has_many :collections
     has_many :entries, through: :collections
     has_many :fields, through: :collections
+
+    has_many :metatags, as: :metatagable
+
+    accepts_nested_attributes_for :metatags, reject_if: :all_blank,
+                                             allow_destroy: true
 
     ##
     # Current site

--- a/app/views/archangel/backend/pages/_form.html.erb
+++ b/app/views/archangel/backend/pages/_form.html.erb
@@ -8,8 +8,6 @@
     <%= f.association :parent, prompt: :translate %>
     <%= f.association :template, prompt: :translate %>
     <%= f.input :content, as: :wysiwyg %>
-    <%= f.input :meta_keywords, as: :meta_keywords %>
-    <%= f.input :meta_description %>
     <%= f.input :published_at, as: :date_time_picker %>
   </div>
 

--- a/app/views/archangel/backend/pages/_form.html.erb
+++ b/app/views/archangel/backend/pages/_form.html.erb
@@ -9,6 +9,18 @@
     <%= f.association :template, prompt: :translate %>
     <%= f.input :content, as: :wysiwyg %>
     <%= f.input :published_at, as: :date_time_picker %>
+
+    <div class="form-group page_metatags">
+      <h3><%= Archangel.t(:metatags) %></h3>
+
+      <%= f.simple_fields_for :metatags do |metatag| %>
+        <%= render "metatag_fields", f: metatag %>
+      <% end %>
+
+      <div class="links">
+        <%= link_to_add_association Archangel.t(:add_metatag), f, :metatags %>
+      </div>
+    </div>
   </div>
 
   <div class="form-actions text-right">

--- a/app/views/archangel/backend/pages/_metatag_fields.html.erb
+++ b/app/views/archangel/backend/pages/_metatag_fields.html.erb
@@ -1,0 +1,6 @@
+<div class="nested-fields">
+  <%= f.input :name %>
+  <%= f.input :content %>
+
+  <%= link_to_remove_association Archangel.t(:remove_metatag), f %>
+</div>

--- a/app/views/archangel/backend/pages/show.html.erb
+++ b/app/views/archangel/backend/pages/show.html.erb
@@ -29,16 +29,6 @@
           </p>
 
           <p>
-            <strong><%= Archangel.t(:meta_keywords) %>:</strong>
-            <%= @page.meta_keywords %>
-          </p>
-
-          <p>
-            <strong><%= Archangel.t(:meta_description) %>:</strong>
-            <%= @page.meta_description %>
-          </p>
-
-          <p>
             <strong><%= Archangel.t(:content) %>:</strong>
             <%= @page.content %>
           </p>

--- a/app/views/archangel/backend/sites/_form.html.erb
+++ b/app/views/archangel/backend/sites/_form.html.erb
@@ -20,6 +20,18 @@
 
     <%= f.input :theme, as: :theme %>
     <%= f.input :locale, as: :language %>
+
+    <div class="form-group site_metatags">
+      <h3><%= Archangel.t(:metatags) %></h3>
+
+      <%= f.simple_fields_for :metatags do |metatag| %>
+        <%= render "metatag_fields", f: metatag %>
+      <% end %>
+
+      <div class="links">
+        <%= link_to_add_association Archangel.t(:add_metatag), f, :metatags %>
+      </div>
+    </div>
   </div>
 
   <div class="form-actions text-right">

--- a/app/views/archangel/backend/sites/_form.html.erb
+++ b/app/views/archangel/backend/sites/_form.html.erb
@@ -20,9 +20,6 @@
 
     <%= f.input :theme, as: :theme %>
     <%= f.input :locale, as: :language %>
-
-    <%= f.input :meta_keywords, as: :meta_keywords %>
-    <%= f.input :meta_description %>
   </div>
 
   <div class="form-actions text-right">

--- a/app/views/archangel/backend/sites/_metatag_fields.html.erb
+++ b/app/views/archangel/backend/sites/_metatag_fields.html.erb
@@ -1,0 +1,6 @@
+<div class="nested-fields">
+  <%= f.input :name %>
+  <%= f.input :content %>
+
+  <%= link_to_remove_association Archangel.t(:remove_metatag), f %>
+</div>

--- a/app/views/archangel/backend/sites/show.html.erb
+++ b/app/views/archangel/backend/sites/show.html.erb
@@ -31,16 +31,6 @@
             <strong><%= Archangel.t(:locale) %>:</strong>
             <%= @site.locale %>
           </p>
-
-          <p>
-            <strong><%= Archangel.t(:meta_keywords) %>:</strong>
-            <%= @site.meta_keywords %>
-          </p>
-
-          <p>
-            <strong><%= Archangel.t(:meta_description) %>:</strong>
-            <%= @site.meta_description %>
-          </p>
         </div>
       </div>
     </div>

--- a/app/views/archangel/frontend/pages/show.json.jbuilder
+++ b/app/views/archangel/frontend/pages/show.json.jbuilder
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 json.page do
-  json.extract! @page, :id, :title, :path, :content, :meta_keywords,
-                :meta_description
+  json.extract! @page, :id, :title, :path, :content
 
   json.published_at @page.published_at.strftime("%F %T")
   json.published_at_timestamp @page.published_at.to_time.to_i

--- a/config/locales/active_record.en.yml
+++ b/config/locales/active_record.en.yml
@@ -42,11 +42,12 @@ en:
         required: Required
         slug: Slug
         value: Default Value
+      archangel/metatag:
+        content: Content
+        name: Name
       archangel/page:
         content: Content
         homepage: Homepage
-        meta_description: META Description
-        meta_keywords: META Keywords
         parent_id: Parent
         published_at: Published At
         slug: Slug
@@ -54,8 +55,6 @@ en:
         title: Title
       archangel/site:
         logo: Logo
-        meta_description: META Description
-        meta_keywords: META Keywords
         name: Name
         remove_logo: Remove Logo
         theme: Theme

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
     actions: Actions
     add_entry: Add Entry
     add_field: Add Field
+    add_metatag: Add Meta Tag
     are_you_sure: Are you sure?
     archangel: Archangel
     assets: Assets
@@ -90,6 +91,7 @@ en:
     logout: Log Out
     meta_description: META Description
     meta_keywords: META Keywords
+    metatags: Meta Tags
     name: Name
     new: New
     new_resource: New %{resource}
@@ -103,6 +105,7 @@ en:
     published: Published
     remove_entry: Remove Entry
     remove_field: Remove Field
+    remove_metatag: Remove Meta Tag
     restricted_path: contains restricted path
     role:
       admin: Admin

--- a/db/migrate/20190113130750_create_archangel_metatags.rb
+++ b/db/migrate/20190113130750_create_archangel_metatags.rb
@@ -1,0 +1,14 @@
+class CreateArchangelMetatags < ActiveRecord::Migration[5.2]
+  def change
+    create_table :archangel_metatags do |t|
+      t.references :metatagable, polymorphic: true, index: false
+      t.string :name
+      t.string :content
+
+      t.timestamps
+    end
+
+    add_index :archangel_metatags, [:metatagable_id, :metatagable_type],
+              name: "index_archangel_metatags_on_metatagable_id_and_type"
+  end
+end

--- a/db/migrate/20190113130751_remove_meta_keywords_and_meta_description_from_archangel_pages.rb
+++ b/db/migrate/20190113130751_remove_meta_keywords_and_meta_description_from_archangel_pages.rb
@@ -1,0 +1,6 @@
+class RemoveMetaKeywordsAndMetaDescriptionFromArchangelPages < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :archangel_pages, :meta_keywords, :string
+    remove_column :archangel_pages, :meta_description, :string
+  end
+end

--- a/db/migrate/20190113130752_remove_meta_keywords_and_meta_description_from_archangel_sites.rb
+++ b/db/migrate/20190113130752_remove_meta_keywords_and_meta_description_from_archangel_sites.rb
@@ -1,0 +1,6 @@
+class RemoveMetaKeywordsAndMetaDescriptionFromArchangelSites < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :archangel_sites, :meta_keywords, :string
+    remove_column :archangel_sites, :meta_description, :string
+  end
+end

--- a/lib/archangel/liquid/drops/page_drop.rb
+++ b/lib/archangel/liquid/drops/page_drop.rb
@@ -10,7 +10,7 @@ module Archangel
       # Liquid drop for a Page
       #
       class PageDrop < Archangel::Liquid::Drop
-        attributes :meta_description, :meta_keywords, :published_at, :title
+        attributes :published_at, :title
 
         # Page id as a string
         #

--- a/lib/archangel/liquid/drops/site_drop.rb
+++ b/lib/archangel/liquid/drops/site_drop.rb
@@ -7,7 +7,7 @@ module Archangel
       # Liquid drop for a Site
       #
       class SiteDrop < Archangel::Liquid::Drop
-        attributes :locale, :meta_description, :meta_keywords, :name
+        attributes :locale, :name
 
         # Original size Site logo URL
         #

--- a/lib/archangel/testing_support/factories/archangel_metatags.rb
+++ b/lib/archangel/testing_support/factories/archangel_metatags.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :metatag, class: "Archangel::Metatag" do
+    association(:metatagable, factory: :page)
+    name { "description" }
+    content { "This is the description of this Page" }
+
+    trait :for_page do
+      association(:metatagable, factory: :page)
+      name { "description" }
+      content { "This is the description of the Page" }
+    end
+
+    trait :for_site do
+      association(:metatagable, factory: :site)
+      name { "description" }
+      content { "This is the description of the Site" }
+    end
+  end
+end

--- a/lib/archangel/testing_support/factories/archangel_pages.rb
+++ b/lib/archangel/testing_support/factories/archangel_pages.rb
@@ -7,8 +7,6 @@ FactoryBot.define do
     sequence(:title) { |n| "Page #{n} Title" }
     sequence(:slug) { |n| "page-#{n}" }
     content { "<p>Content of the page</p>" }
-    meta_keywords { "default,keywords,of,my,page" }
-    meta_description { "Default description of my page" }
     homepage { false }
     published_at { Time.current }
 

--- a/lib/archangel/testing_support/factories/archangel_sites.rb
+++ b/lib/archangel/testing_support/factories/archangel_sites.rb
@@ -6,8 +6,6 @@ FactoryBot.define do
 
     sequence(:name) { |n| "Site #{n} Name" }
     locale { "en" }
-    meta_keywords { "default,keywords,of,my,site" }
-    meta_description { "Default description of my site" }
 
     trait :logo do
       logo { fixture_file_upload(uploader_test_image) }

--- a/lib/archangel/testing_support/matchers/have_meta.rb
+++ b/lib/archangel/testing_support/matchers/have_meta.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :have_meta do |name, expected|
+  match do |_actual|
+    has_css?("meta[name='#{name}'][content='#{expected}']", visible: false)
+  end
+
+  failure_message do |_actual|
+    actual = first("meta[name='#{name}']")
+
+    if actual
+      "expected that meta #{name} would have content='#{expected}' " \
+      "but was '#{actual[:content]}'"
+    else
+      "expected that meta #{name} would exist with content='#{expected}'"
+    end
+  end
+end

--- a/lib/archangel/testing_support/matchers/have_title.rb
+++ b/lib/archangel/testing_support/matchers/have_title.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :have_title do |expected|
+  match do |_actual|
+    has_css?("title", text: expected)
+  end
+
+  failure_message_for_should do |_actual|
+    actual = first("title")
+
+    if actual
+      "expected that title would have been '#{expected}' " \
+      "but was '#{actual.text}'"
+    else
+      "expected that title would exist with '#{expected}'"
+    end
+  end
+end

--- a/spec/controllers/archangel/backend/pages_controller_spec.rb
+++ b/spec/controllers/archangel/backend/pages_controller_spec.rb
@@ -45,7 +45,17 @@ module Archangel
             {
               title: "New Page Title",
               content: "<p>New page content</p>",
-              slug: "awesome-page"
+              slug: "awesome-page",
+              metatags_attributes: [
+                {
+                  name: "description",
+                  content: "Description for the Page"
+                },
+                {
+                  name: "keywords",
+                  content: "keywords,for,the,Page"
+                }
+              ]
             }
           end
 
@@ -53,6 +63,12 @@ module Archangel
             expect do
               post :create, params: { page: params }
             end.to change(Page, :count).by(1)
+          end
+
+          it "creates Metatag resources" do
+            expect do
+              post :create, params: { page: params }
+            end.to change(Metatag, :count).by(2)
           end
 
           it "assigns a newly created resource as @page" do

--- a/spec/features/frontend/liquid_drop_variables_spec.rb
+++ b/spec/features/frontend/liquid_drop_variables_spec.rb
@@ -82,8 +82,6 @@ RSpec.feature "Default variables", type: :feature do
         Page ID: {{ page.id }}
         Page Title: {{ page.title }}
         Page Path: {{ page.path }}
-        Page Meta Keywords: {{ page.meta_keywords }}
-        Page Meta Description: {{ page.meta_description }}
         Page Published At: {{ page.published_at }}
         Page Unknown: ~{{ page.unknown_variable }}~
       CONTENT
@@ -96,10 +94,6 @@ RSpec.feature "Default variables", type: :feature do
       expect(page).to have_content("Page Title: #{resource.title}")
       expect(page).to have_content("Page Path: /#{resource.path}")
       expect(page)
-        .to have_content("Page Meta Keywords: #{resource.meta_keywords}")
-      expect(page)
-        .to have_content("Page Meta Description: #{resource.meta_description}")
-      expect(page)
         .to have_content("Page Published At: #{resource.published_at}")
       expect(page).to have_content("Page Unknown: ~~")
     end
@@ -110,8 +104,6 @@ RSpec.feature "Default variables", type: :feature do
       content = <<-CONTENT
         Site Name: {{ site.name }}
         Site Locale: {{ site.locale }}
-        Site Meta Keywords: {{ site.meta_keywords }}
-        Site Meta Description: {{ site.meta_description }}
         Site Logo: {{ site.logo }}
         Site Unknown: ~{{ site.unknown_variable }}~
       CONTENT
@@ -122,9 +114,6 @@ RSpec.feature "Default variables", type: :feature do
 
       expect(page).to have_content("Site Name: #{site.name}")
       expect(page).to have_content("Site Locale: #{site.locale}")
-      expect(page).to have_content("Site Meta Keywords: #{site.meta_keywords}")
-      expect(page)
-        .to have_content("Site Meta Description: #{site.meta_description}")
       expect(page).to have_content("Site Logo: #{site.logo}")
       expect(page).to have_content("Site Unknown: ~~")
     end

--- a/spec/features/frontend/pages/metatags_spec.rb
+++ b/spec/features/frontend/pages/metatags_spec.rb
@@ -58,16 +58,16 @@ RSpec.feature "Meta tag", type: :feature do
       expect(page).to have_title("#{resource.title} | #{site.name}")
     end
 
-    it "always uses Page title (page.title) for HTML title" do
+    it "always uses page.title for title (doesn't allow metatag overwrite)" do
       resource = create(:page, site: site)
       create(:metatag, metatagable: resource,
                        name: "title",
-                       content: "Unused Page Title")
+                       content: "Metatag Page Title")
 
       visit archangel.frontend_page_path(resource.path)
 
       expect(page).to have_title("#{resource.title} | #{site.name}")
-      expect(page).to_not have_title("Unused Page Title | #{site.name}")
+      expect(page).to_not have_title("Metatag Page Title | #{site.name}")
     end
   end
 end

--- a/spec/features/frontend/pages/metatags_spec.rb
+++ b/spec/features/frontend/pages/metatags_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Meta tag", type: :feature do
+  describe "site metatags" do
+    let(:site) { create(:site) }
+
+    before do
+      create(:metatag, metatagable: site,
+                       name: "description",
+                       content: "Site description")
+      create(:metatag, metatagable: site,
+                       name: "author",
+                       content: "Archangel")
+    end
+
+    it "contains default meta tags" do
+      resource = create(:page, site: site)
+
+      visit archangel.frontend_page_path(resource.path)
+
+      canonical = "http://www.example.com/#{resource.path}"
+
+      expect(page).to(
+        have_css(
+          "link[rel='canonical'][href='#{canonical}']", visible: false
+        )
+      )
+    end
+
+    it "contains Site meta tags" do
+      resource = create(:page, site: site)
+
+      visit archangel.frontend_page_path(resource.path)
+
+      expect(page).to have_meta(:description, "Site description")
+      expect(page).to have_meta(:author, "Archangel")
+
+      expect(page).to have_title("#{resource.title} | #{site.name}")
+    end
+
+    it "contains Site and Page meta tags" do
+      resource = create(:page, site: site)
+      create(:metatag, metatagable: resource,
+                       name: "description",
+                       content: "Page description")
+      create(:metatag, metatagable: resource,
+                       name: "keywords",
+                       content: "useful,page,keywords")
+
+      visit archangel.frontend_page_path(resource.path)
+
+      expect(page).to have_meta(:description, "Page description")
+      expect(page).to have_meta(:keywords, "useful,page,keywords")
+      expect(page).to have_meta(:author, "Archangel")
+
+      expect(page).to have_title("#{resource.title} | #{site.name}")
+    end
+
+    it "always uses Page title (page.title) for HTML title" do
+      resource = create(:page, site: site)
+      create(:metatag, metatagable: resource,
+                       name: "title",
+                       content: "Unused Page Title")
+
+      visit archangel.frontend_page_path(resource.path)
+
+      expect(page).to have_title("#{resource.title} | #{site.name}")
+      expect(page).to_not have_title("Unused Page Title | #{site.name}")
+    end
+  end
+end

--- a/spec/lib/archangel/liquid/drops/page_drop_spec.rb
+++ b/spec/lib/archangel/liquid/drops/page_drop_spec.rb
@@ -9,8 +9,6 @@ module Archangel
         let(:resource) do
           create(:page, title: "Test Page",
                         slug: "path-for-page",
-                        meta_keywords: "keywords,for,page",
-                        meta_description: "Description of page",
                         published_at: "2018-04-20 14:20:18")
         end
         let(:resource_drop) { described_class.new(resource) }
@@ -18,12 +16,10 @@ module Archangel
         context "attributes" do
           it "_attributes" do
             expect(resource_drop.class._attributes)
-              .to eq(%i[meta_description meta_keywords published_at title])
+              .to eq(%i[published_at title])
           end
 
           it "returns correct attribute values" do
-            expect(resource_drop.meta_description).to eq("Description of page")
-            expect(resource_drop.meta_keywords).to eq("keywords,for,page")
             expect(resource_drop.published_at).to eq("2018-04-20 14:20:18")
             expect(resource_drop.title).to eq("Test Page")
           end
@@ -40,8 +36,6 @@ module Archangel
         context "#as_json" do
           it "returns hash of attributes" do
             json_object = {
-              meta_description: "Description of page",
-              meta_keywords: "keywords,for,page",
               published_at: "2018-04-20T14:20:18.000Z",
               title: "Test Page"
             }
@@ -53,8 +47,6 @@ module Archangel
         context "#to_json" do
           it "returns hash of attributes" do
             json_object = {
-              meta_description: "Description of page",
-              meta_keywords: "keywords,for,page",
               published_at: "2018-04-20T14:20:18.000Z",
               title: "Test Page"
             }

--- a/spec/lib/archangel/liquid/drops/site_drop_spec.rb
+++ b/spec/lib/archangel/liquid/drops/site_drop_spec.rb
@@ -7,23 +7,17 @@ module Archangel
     module Drops
       RSpec.describe SiteDrop, type: :liquid_drop do
         let(:resource) do
-          create(:site, name: "Test Site",
-                        locale: "en",
-                        meta_keywords: "keywords,for,site",
-                        meta_description: "Description of site")
+          create(:site, name: "Test Site", locale: "en")
         end
         let(:resource_drop) { described_class.new(resource) }
 
         context "attributes" do
           it "_attributes" do
-            expect(resource_drop.class._attributes)
-              .to eq(%i[locale meta_description meta_keywords name])
+            expect(resource_drop.class._attributes).to eq(%i[locale name])
           end
 
           it "returns correct attribute values" do
             expect(resource_drop.locale).to eq("en")
-            expect(resource_drop.meta_description).to eq("Description of site")
-            expect(resource_drop.meta_keywords).to eq("keywords,for,site")
             expect(resource_drop.name).to eq("Test Site")
           end
 
@@ -37,8 +31,6 @@ module Archangel
           it "returns hash of attributes" do
             json_object = {
               locale: "en",
-              meta_description: "Description of site",
-              meta_keywords: "keywords,for,site",
               name: "Test Site"
             }
 
@@ -50,8 +42,6 @@ module Archangel
           it "returns hash of attributes" do
             json_object = {
               locale: "en",
-              meta_description: "Description of site",
-              meta_keywords: "keywords,for,site",
               name: "Test Site"
             }
 

--- a/spec/models/archangel/metatag_spec.rb
+++ b/spec/models/archangel/metatag_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module Archangel
   RSpec.describe Metatag, type: :model do
     context "validations" do
-      it "has a unique path scoped to Site" do
+      it "has a unique name scoped to metatagable_type and metatagable_id" do
         resource = build(:metatag)
 
         expect(resource).to(

--- a/spec/models/archangel/metatag_spec.rb
+++ b/spec/models/archangel/metatag_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Archangel
+  RSpec.describe Metatag, type: :model do
+    context "validations" do
+      it "has a unique path scoped to Site" do
+        resource = build(:metatag)
+
+        expect(resource).to(
+          validate_uniqueness_of(:name)
+            .scoped_to(:metatagable_type, :metatagable_id)
+        )
+      end
+    end
+
+    context "associations" do
+      it { is_expected.to belong_to(:metatagable) }
+    end
+  end
+end

--- a/spec/models/archangel/page_spec.rb
+++ b/spec/models/archangel/page_spec.rb
@@ -56,6 +56,8 @@ module Archangel
       it { is_expected.to belong_to(:site) }
       it { is_expected.to belong_to(:parent).class_name("Archangel::Page") }
       it { is_expected.to belong_to(:template).conditions(partial: false) }
+
+      it { is_expected.to have_many(:metatags) }
     end
 
     context "scopes" do

--- a/spec/models/archangel/site_spec.rb
+++ b/spec/models/archangel/site_spec.rb
@@ -23,10 +23,12 @@ module Archangel
 
     it { is_expected.to have_many(:assets) }
     it { is_expected.to have_many(:collections) }
+    it { is_expected.to have_many(:metatags) }
     it { is_expected.to have_many(:pages) }
     it { is_expected.to have_many(:templates) }
     it { is_expected.to have_many(:users) }
     it { is_expected.to have_many(:widgets) }
+
     it { is_expected.to have_many(:entries).through(:collections) }
     it { is_expected.to have_many(:fields).through(:collections) }
 


### PR DESCRIPTION
# Summary

Rethinking the way to do meta tags. Instead of having a strict number of meta tags (`meta_keywords` and `meta_description` in the Site and Page models), use a polymorphic table to manage the various types of meta tags. This would allow a wider number of meta tags for a larger number of tables.

## What's New

* Migration to create `archangel_metatags` to manage meta tags for various controllers. Currently Sites and Pages.
* Migration to remove `meta_keywords` and `meta_description` from `archangel_sites`
* Migration to remove `meta_keywords` and `meta_description` from `archangel_pages`

## What's Changed

* Remove all traces of `meta_keywords` and `meta_description` from Site
* Remove all traces of `meta_keywords` and `meta_description` from Page