### PR TITLE
pages.permalink

### DIFF
--- a/app/controllers/archangel/backend/pages_controller.rb
+++ b/app/controllers/archangel/backend/pages_controller.rb
@@ -15,7 +15,7 @@ module Archangel
 
       def permitted_attributes
         [
-          :content, :homepage, :parent_id, :path, :published_at, :slug,
+          :content, :homepage, :parent_id, :permalink, :published_at, :slug,
           :template_id, :title,
           metatags_attributes: %i[id _destroy name content]
         ]

--- a/app/controllers/archangel/frontend/pages_controller.rb
+++ b/app/controllers/archangel/frontend/pages_controller.rb
@@ -20,17 +20,17 @@ module Archangel
       #   HTML, JSON
       #
       # Params
-      #   [String] path - the path to the page
+      #   [String] permalink - the permalink to the page
       #
       # Request
-      #   GET /:path
-      #   GET /:path.json
+      #   GET /:permalink
+      #   GET /:permalink.json
       #
       # Response
       #   {
       #     "id": 123,
       #     "title": "Page Title",
-      #     "path": "path/to/page",
+      #     "permalink": "path/to/page",
       #     "content": "</p>Content of the page</p>",
       #     "homepage": false,
       #     "published_at": "YYYY-MM-DDTHH:MM:SS.MSZ",
@@ -60,9 +60,13 @@ module Archangel
       # Find and assign resource to the view
       #
       def set_resource
-        page_path = params.fetch(:path, nil)
+        page_permalink = params.fetch(:permalink, nil)
 
-        @page = page_path.blank? ? find_homepage : find_page(page_path)
+        @page = if page_permalink.blank?
+                  find_homepage
+                else
+                  find_page(page_permalink)
+                end
       end
 
       ##
@@ -87,18 +91,18 @@ module Archangel
       end
 
       ##
-      # Check to redirect to homepage root path
+      # Check to redirect to homepage root permalink
       #
       # @return [Boolean] redirect or not
       #
       def redirect_to_homepage?
         return false unless @page
 
-        (params.fetch(:path, nil) == @page.path) && @page.homepage?
+        (params.fetch(:permalink, nil) == @page.permalink) && @page.homepage?
       end
 
       ##
-      # Redirect to homepage root path is page is marked as the homepage
+      # Redirect to homepage root permalink is page is marked as the homepage
       #
       def redirect_to_homepage
         redirect_to root_path, status: :moved_permanently
@@ -118,8 +122,8 @@ module Archangel
       #
       # @return [Object] the page
       #
-      def find_page(path)
-        current_site.pages.published.find_by!(path: path)
+      def find_page(permalink)
+        current_site.pages.published.find_by!(permalink: permalink)
       end
 
       ##

--- a/app/helpers/archangel/application_helper.rb
+++ b/app/helpers/archangel/application_helper.rb
@@ -6,7 +6,7 @@ module Archangel
   #
   module ApplicationHelper
     ##
-    # Frontend resource path.
+    # Frontend resource permalink.
     #
     # Same as `frontend_page_path` except it prints out nested resources in a
     # nice way.
@@ -15,17 +15,17 @@ module Archangel
     #   <%= frontend_resource_path('foo/bar') %> #=> /foo/bar
     #   <%= frontend_resource_path(@page) %> #=> /foo/bar
     #
-    # @return [String] frontend resource path
+    # @return [String] frontend resource permalink
     #
     def frontend_resource_path(resource)
-      permalink_path = proc do |path|
-        archangel.frontend_page_path(path).gsub("%2F", "/")
+      permalink_path = proc do |permalink|
+        archangel.frontend_page_path(permalink).gsub("%2F", "/")
       end
 
       return permalink_path.call(resource) unless resource.class == Page
       return archangel.frontend_root_path if resource.homepage?
 
-      permalink_path.call(resource.path)
+      permalink_path.call(resource.permalink)
     end
 
     ##

--- a/app/models/archangel/page.rb
+++ b/app/models/archangel/page.rb
@@ -12,7 +12,7 @@ module Archangel
 
     before_validation :parameterize_slug
 
-    before_save :build_page_path
+    before_save :build_page_permalink
 
     after_save :homepage_reset
 
@@ -20,7 +20,7 @@ module Archangel
 
     validates :content, presence: true
     validates :homepage, inclusion: { in: [true, false] }
-    validates :path, uniqueness: { scope: :site_id }
+    validates :permalink, uniqueness: { scope: :site_id }
     validates :published_at, allow_blank: true, date: true
     validates :slug, presence: true,
                      uniqueness: { scope: %i[parent_id site_id] }
@@ -102,10 +102,10 @@ module Archangel
       self.slug = slug.to_s.downcase.parameterize
     end
 
-    def build_page_path
-      parent_path = parent.blank? ? nil : parent.path
+    def build_page_permalink
+      parent_permalink = parent.blank? ? nil : parent.permalink
 
-      self.path = [parent_path, slug].compact.join("/")
+      self.permalink = [parent_permalink, slug].compact.join("/")
     end
 
     def homepage_reset

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,11 +158,11 @@ Archangel::Engine.routes.draw do
   end
 
   namespace :frontend, path: Archangel.config.frontend_path do
-    # GET /[PATH]
-    get ":path", to: "pages#show", as: :page,
-                 constraints: {
-                   path: %r{[\w\-\/]+}
-                 }
+    # GET /[PERMALINK]
+    get ":permalink", to: "pages#show", as: :page,
+                      constraints: {
+                        permalink: %r{[\w\-\/]+}
+                      }
 
     # GET /
     root to: "pages#show"

--- a/db/migrate/20190408164034_rename_archangel_pages_path_to_permalink.rb
+++ b/db/migrate/20190408164034_rename_archangel_pages_path_to_permalink.rb
@@ -1,0 +1,5 @@
+class RenameArchangelPagesPathToPermalink < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :archangel_pages, :path, :permalink
+  end
+end

--- a/lib/archangel/liquid/drops/page_drop.rb
+++ b/lib/archangel/liquid/drops/page_drop.rb
@@ -20,12 +20,12 @@ module Archangel
           object.id.to_s
         end
 
-        # Page path with leading slash
+        # Page permalink with leading slash
         #
-        # @return [String] the path
+        # @return [String] the permalink
         #
-        def path
-          "/#{object.path}"
+        def permalink
+          "/#{object.permalink}"
         end
       end
     end

--- a/spec/controllers/archangel/frontend/pages_controller_spec.rb
+++ b/spec/controllers/archangel/frontend/pages_controller_spec.rb
@@ -9,7 +9,7 @@ module Archangel
 
       describe "loads correct layout" do
         it "loads correct view" do
-          get :show, params: { path: page.path }
+          get :show, params: { permalink: page.permalink }
 
           expect(response).to render_with_layout("frontend")
         end
@@ -17,14 +17,14 @@ module Archangel
 
       describe "GET #show" do
         it "assigns the requested page as @page" do
-          get :show, params: { path: page.path }
+          get :show, params: { permalink: page.permalink }
 
           expect(response.content_type).to eq "text/html"
           expect(assigns(:page)).to eq(page)
         end
 
         it "assigns the requested page as @page for JSON request" do
-          get :show, params: { path: page.path }, format: :json
+          get :show, params: { permalink: page.permalink }, format: :json
 
           expect(response.content_type).to eq "application/json"
           expect(assigns(:page)).to eq(page)
@@ -33,14 +33,14 @@ module Archangel
         it "redirects to homepage" do
           page = create(:page, :homepage)
 
-          get :show, params: { path: page.path }
+          get :show, params: { permalink: page.permalink }
 
           expect(response).to redirect_to(root_path)
           expect(response.status).to eq(301)
         end
 
         it "returns a 404 status code when page is not found" do
-          get :show, params: { path: "not-a-real-page" }
+          get :show, params: { permalink: "not-a-real-page" }
 
           expect(response).to render_template("archangel/errors/error_404")
           expect(response).to have_http_status(:not_found)

--- a/spec/features/frontend/liquid_drop_variables_spec.rb
+++ b/spec/features/frontend/liquid_drop_variables_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Default variables", type: :feature do
 
       resource = create(:page, site: site, slug: "foo", content: content)
 
-      visit archangel.frontend_page_path(resource.path)
+      visit archangel.frontend_page_path(resource.permalink)
 
       expect(page).to have_content("Current Page: /foo")
     end
@@ -25,14 +25,14 @@ RSpec.feature "Default variables", type: :feature do
                                slug: "bar",
                                content: content)
 
-      visit CGI.unescape(archangel.frontend_page_path(resource.path))
+      visit CGI.unescape(archangel.frontend_page_path(resource.permalink))
 
       expect(page).to have_content("Current Page: /foo/bar")
     end
 
     it "knows it is on the current page" do
       content = <<-CONTENT
-        {% if current_page == page.path %}
+        {% if current_page == page.permalink %}
           Current Page?: Yup!
         {% else %}
           Current Page?: Nope!
@@ -41,7 +41,7 @@ RSpec.feature "Default variables", type: :feature do
 
       post = create(:page, site: site, content: content)
 
-      visit archangel.frontend_page_path(post.path)
+      visit archangel.frontend_page_path(post.permalink)
 
       expect(page).to have_content("Current Page?: Yup!")
       expect(page).not_to have_content("Current Page?: Nope!")
@@ -58,7 +58,7 @@ RSpec.feature "Default variables", type: :feature do
 
       post = create(:page, site: site, content: content)
 
-      visit archangel.frontend_page_path(post.path)
+      visit archangel.frontend_page_path(post.permalink)
 
       expect(page).not_to have_content("Current Page?: Yup!")
       expect(page).to have_content("Current Page?: Nope!")
@@ -70,7 +70,7 @@ RSpec.feature "Default variables", type: :feature do
 
       resource = create(:page, site: site, slug: slug, content: content)
 
-      visit archangel.frontend_page_path(resource.path)
+      visit archangel.frontend_page_path(resource.permalink)
 
       expect(page).to have_content("Current Page: /#{slug}")
     end
@@ -81,18 +81,18 @@ RSpec.feature "Default variables", type: :feature do
       content = <<-CONTENT
         Page ID: {{ page.id }}
         Page Title: {{ page.title }}
-        Page Path: {{ page.path }}
+        Page Permalink: {{ page.permalink }}
         Page Published At: {{ page.published_at }}
         Page Unknown: ~{{ page.unknown_variable }}~
       CONTENT
 
       resource = create(:page, site: site, content: content)
 
-      visit archangel.frontend_page_path(resource.path)
+      visit archangel.frontend_page_path(resource.permalink)
 
       expect(page).to have_content("Page ID: #{resource.id}")
       expect(page).to have_content("Page Title: #{resource.title}")
-      expect(page).to have_content("Page Path: /#{resource.path}")
+      expect(page).to have_content("Page Permalink: /#{resource.permalink}")
       expect(page)
         .to have_content("Page Published At: #{resource.published_at}")
       expect(page).to have_content("Page Unknown: ~~")
@@ -110,7 +110,7 @@ RSpec.feature "Default variables", type: :feature do
 
       resource = create(:page, site: site, content: content)
 
-      visit archangel.frontend_page_path(resource.path)
+      visit archangel.frontend_page_path(resource.permalink)
 
       expect(page).to have_content("Site Name: #{site.name}")
       expect(page).to have_content("Site Locale: #{site.locale}")
@@ -125,7 +125,7 @@ RSpec.feature "Default variables", type: :feature do
 
       resource = create(:page, site: site, content: content)
 
-      visit archangel.frontend_page_path(resource.path)
+      visit archangel.frontend_page_path(resource.permalink)
 
       expect(page).to have_content("Unknown Variable: ~~")
     end

--- a/spec/features/frontend/pages/homepage_redirect_spec.rb
+++ b/spec/features/frontend/pages/homepage_redirect_spec.rb
@@ -3,11 +3,11 @@
 require "rails_helper"
 
 RSpec.feature "Home page", type: :feature do
-  describe "when on home page path" do
+  describe "when on home page permalink" do
     it "redirects to /" do
       resource = create(:page, :homepage)
 
-      visit archangel.frontend_page_path(resource.path)
+      visit archangel.frontend_page_path(resource.permalink)
 
       expect(page.current_path).to eq archangel.frontend_root_path
     end

--- a/spec/features/frontend/pages/metatags_spec.rb
+++ b/spec/features/frontend/pages/metatags_spec.rb
@@ -18,9 +18,9 @@ RSpec.feature "Meta tag", type: :feature do
     it "contains default meta tags" do
       resource = create(:page, site: site)
 
-      visit archangel.frontend_page_path(resource.path)
+      visit archangel.frontend_page_path(resource.permalink)
 
-      canonical = "http://www.example.com/#{resource.path}"
+      canonical = "http://www.example.com/#{resource.permalink}"
 
       expect(page).to(
         have_css(
@@ -32,7 +32,7 @@ RSpec.feature "Meta tag", type: :feature do
     it "contains Site meta tags" do
       resource = create(:page, site: site)
 
-      visit archangel.frontend_page_path(resource.path)
+      visit archangel.frontend_page_path(resource.permalink)
 
       expect(page).to have_meta(:description, "Site description")
       expect(page).to have_meta(:author, "Archangel")
@@ -49,7 +49,7 @@ RSpec.feature "Meta tag", type: :feature do
                        name: "keywords",
                        content: "useful,page,keywords")
 
-      visit archangel.frontend_page_path(resource.path)
+      visit archangel.frontend_page_path(resource.permalink)
 
       expect(page).to have_meta(:description, "Page description")
       expect(page).to have_meta(:keywords, "useful,page,keywords")
@@ -64,7 +64,7 @@ RSpec.feature "Meta tag", type: :feature do
                        name: "title",
                        content: "Metatag Page Title")
 
-      visit archangel.frontend_page_path(resource.path)
+      visit archangel.frontend_page_path(resource.permalink)
 
       expect(page).to have_title("#{resource.title} | #{site.name}")
       expect(page).to_not have_title("Metatag Page Title | #{site.name}")

--- a/spec/lib/archangel/liquid/drops/page_drop_spec.rb
+++ b/spec/lib/archangel/liquid/drops/page_drop_spec.rb
@@ -28,8 +28,8 @@ module Archangel
             expect(resource_drop.id).to eq(resource.id.to_s)
           end
 
-          it "returns correct #path value" do
-            expect(resource_drop.path).to eq("/path-for-page")
+          it "returns correct #permalink value" do
+            expect(resource_drop.permalink).to eq("/path-for-page")
           end
         end
 

--- a/spec/models/archangel/page_spec.rb
+++ b/spec/models/archangel/page_spec.rb
@@ -7,7 +7,7 @@ module Archangel
     context "callbacks" do
       it { is_expected.to callback(:parameterize_slug).before(:validation) }
 
-      it { is_expected.to callback(:build_page_path).before(:save) }
+      it { is_expected.to callback(:build_page_permalink).before(:save) }
 
       it { is_expected.to callback(:homepage_reset).after(:save) }
 
@@ -33,10 +33,12 @@ module Archangel
 
       it { is_expected.to_not allow_value("invalid").for(:published_at) }
 
-      it "has a unique path scoped to Site" do
+      it "has a unique permalink scoped to Site" do
         resource = build(:page)
 
-        expect(resource).to validate_uniqueness_of(:path).scoped_to(:site_id)
+        expect(resource).to(
+          validate_uniqueness_of(:permalink).scoped_to(:site_id)
+        )
       end
 
       it "has a unique slug scoped to Parent and Site" do

--- a/spec/requests/frontend/homepage_spec.rb
+++ b/spec/requests/frontend/homepage_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe "Frontend - Homepage", type: :request do
       expect(response).to be_successful
     end
 
-    it "redirects to frontend_root_path when homepage path requested" do
-      get "/#{homepage.path}"
+    it "redirects to frontend_root_path when homepage permalink requested" do
+      get "/#{homepage.permalink}"
 
       expect(response).to redirect_to("/")
     end


### PR DESCRIPTION
# Summary

It was decided that `pages.permalink` makes more sense than `pages.path`. This adds a migration to rename the database column and updates all references to the new column name.

## What's New

* Migration to rename `pages.path` column to `pages.permalink`

## What's Changed

* Change references to Page `path` to `permalink`