### PR TITLE
Update Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ script:
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 rvm:
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.1
+  - 2.4.6
+  - 2.5.5
+  - 2.6.2

--- a/archangel.gemspec
+++ b/archangel.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files -z`.split("\x0")
   s.executables = ["archangel"]
 
-  s.required_ruby_version = ">= 2.3.8"
+  s.required_ruby_version = ">= 2.4"
 
   s.add_dependency "jquery-rails", "~> 4.1", ">= 4.1.0"
   s.add_dependency "rails", "~> 5.1", ">= 5.1.4"


### PR DESCRIPTION
# Summary

Ruby 2.3 is no longer supported. Remove it from the `.travis.yml` file and bump to the latest of the minor version lines.

## What's New

Nothing

## What's Changed

* Update `required_ruby_version` to `>= 2.4` in `archangel.gemspec`
* Remove Ruby 2.3 from `.travis.yml`
* Update Ruby 2.4 to 2.4.6 in `.travis.yml`
* Update Ruby 2.5 to 2.5.5 in `.travis.yml`
* Update Ruby 2.6 to 2.6.2 in `.travis.yml`