### PR TITLE
MetatagableConcern

### DIFF
--- a/app/controllers/archangel/auth_controller.rb
+++ b/app/controllers/archangel/auth_controller.rb
@@ -5,6 +5,8 @@ module Archangel
   # Authentication base controller
   #
   class AuthController < ApplicationController
+    include Archangel::Controllers::MetatagableConcern
+
     before_action :configure_permitted_parameters
 
     protected
@@ -15,6 +17,10 @@ module Archangel
 
     def configure_permitted_parameters
       devise_parameter_sanitizer.permit(:sign_up, keys: %i[name username])
+    end
+
+    def default_meta_tags
+      super.merge(noindex: true, nofollow: true, noarchive: true)
     end
   end
 end

--- a/app/controllers/archangel/backend_controller.rb
+++ b/app/controllers/archangel/backend_controller.rb
@@ -9,6 +9,7 @@ module Archangel
 
     include Archangel::Controllers::AuthenticatableConcern
     include Archangel::Controllers::AuthorizableConcern
+    include Archangel::Controllers::MetatagableConcern
 
     rescue_from Pundit::NotAuthorizedError, with: :render_401_error
 
@@ -16,6 +17,10 @@ module Archangel
 
     def layout_from_theme
       "backend"
+    end
+
+    def default_meta_tags
+      super.merge(noindex: true, nofollow: true, noarchive: true)
     end
   end
 end

--- a/app/controllers/archangel/frontend/pages_controller.rb
+++ b/app/controllers/archangel/frontend/pages_controller.rb
@@ -10,8 +10,8 @@ module Archangel
     #
     class PagesController < FrontendController
       before_action :set_resource, only: %i[show]
-      before_action :assign_meta_tags, if: -> { request.get? },
-                                       unless: -> { request.xhr? }
+      before_action :assign_resource_meta_tags, if: -> { request.get? },
+                                                unless: -> { request.xhr? }
 
       ##
       # Frontend page
@@ -72,8 +72,8 @@ module Archangel
       ##
       # Assign meta tags to view
       #
-      def assign_meta_tags
-        apply_meta_tags(page_meta_tags)
+      def assign_resource_meta_tags
+        assign_meta_tags(resource_meta_tags)
       end
 
       ##
@@ -81,13 +81,16 @@ module Archangel
       #
       # @return [Object] the page meta tags
       #
-      def page_meta_tags
-        [
+      def resource_meta_tags
+        meta_tags = [
           current_site.metatags,
           @page.metatags
         ].flatten.inject({}) do |tags, metatag|
           tags.merge(metatag.name => metatag.content)
-        end.merge(title: @page.title)
+        end
+
+        { image_src: current_site.logo.url }.merge(meta_tags)
+                                            .merge(title: @page.title)
       end
 
       ##

--- a/app/controllers/archangel/frontend_controller.rb
+++ b/app/controllers/archangel/frontend_controller.rb
@@ -5,6 +5,6 @@ module Archangel
   # Frontend base controller
   #
   class FrontendController < ApplicationController
-    include Archangel::Controllers::SeoableConcern
+    include Archangel::Controllers::MetatagableConcern
   end
 end

--- a/app/controllers/concerns/archangel/controllers/metatagable_concern.rb
+++ b/app/controllers/concerns/archangel/controllers/metatagable_concern.rb
@@ -6,9 +6,9 @@ module Archangel
   #
   module Controllers
     ##
-    # Controller SEO concern
+    # Controller meta tag concern
     #
-    module SeoableConcern
+    module MetatagableConcern
       extend ActiveSupport::Concern
 
       included do
@@ -21,7 +21,7 @@ module Archangel
       #
       # @param meta_tags [Hash] list of meta tags
       #
-      def apply_meta_tags(meta_tags = {})
+      def assign_meta_tags(meta_tags = {})
         meta = meta_tags.reject { |_name, value| value.blank? }
 
         set_meta_tags(meta)
@@ -30,15 +30,14 @@ module Archangel
       protected
 
       def apply_default_meta_tags
-        apply_meta_tags(default_meta_tags)
+        assign_meta_tags(default_meta_tags)
       end
 
       def default_meta_tags
         {
           reverse: true,
           site: current_site.name,
-          canonical: request.url,
-          image_src: current_site.logo.url
+          canonical: request.url
         }
       end
     end

--- a/app/themes/default/views/layouts/auth.html.erb
+++ b/app/themes/default/views/layouts/auth.html.erb
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <title><%= content_for?(:title) ? yield(:title) : Archangel.t(:archangel) %></title>
+    <%= display_meta_tags %>
 
     <%= csrf_meta_tags %>
 

--- a/app/themes/default/views/layouts/backend.html.erb
+++ b/app/themes/default/views/layouts/backend.html.erb
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <title><%= content_for?(:title) ? yield(:title) : Archangel.t(:archangel) %></title>
+    <%= display_meta_tags %>
 
     <%= csrf_meta_tags %>
 


### PR DESCRIPTION
# Summary

Rename `SeoableConcern` to `MetatagableConcern` since it's purpose is to show meta tags, not manage all things SEO. Clean up and rename methods so they are more clear of their purpose.

## What's New

* Extend metatag functionality to Auth (sets `noindex`, `nofollow` and `noarchive` by default)
* Extend metatag functionality to Backend (sets `noindex`, `nofollow` and `noarchive` by default)

## What's Changed

* Rename `Archangel::Controllers::SeoableConcern` to `Archangel::Controllers::MetatagableConcern`
* Rename meta tag functions in Frontend that applied meta tags to make them more clear