### PR TITLE
Introduce archangel_sites.allow_registration

### DIFF
--- a/app/controllers/archangel/auth/registrations_controller.rb
+++ b/app/controllers/archangel/auth/registrations_controller.rb
@@ -27,7 +27,7 @@ module Archangel
       end
 
       def allow_registration
-        return render_404_error unless Archangel.config.allow_registration
+        return render_404_error unless current_site.allow_registration?
       end
     end
   end

--- a/app/controllers/archangel/backend/sites_controller.rb
+++ b/app/controllers/archangel/backend/sites_controller.rb
@@ -145,6 +145,7 @@ module Archangel
       def permitted_attributes
         [
           :locale, :logo, :name, :remove_logo, :theme,
+          :allow_registration,
           metatags_attributes: %i[id _destroy name content]
         ]
       end

--- a/app/models/archangel/site.rb
+++ b/app/models/archangel/site.rb
@@ -11,7 +11,7 @@ module Archangel
 
     typed_store :settings, coder: JSON do |s|
       s.boolean :allow_registration, default: false
-      s.datetime :preferred_at, default: Time.now
+      s.datetime :preferred_at, default: Time.now, accessor: false
     end
 
     validates :locale, presence: true, inclusion: { in: Archangel::LANGUAGES }

--- a/app/models/archangel/site.rb
+++ b/app/models/archangel/site.rb
@@ -9,12 +9,19 @@ module Archangel
 
     mount_uploader :logo, Archangel::LogoUploader
 
+    typed_store :settings, coder: JSON do |s|
+      s.boolean :allow_registration, default: false
+      s.datetime :preferred_at, default: Time.now
+    end
+
     validates :locale, presence: true, inclusion: { in: Archangel::LANGUAGES }
     validates :logo, file_size: {
       less_than_or_equal_to: Archangel.config.image_maximum_file_size
     }
     validates :name, presence: true
     validates :theme, inclusion: { in: Archangel.themes }, allow_blank: true
+
+    validates :allow_registration, inclusion: { in: [true, false] }
 
     has_many :assets
     has_many :collections

--- a/app/models/archangel/user.rb
+++ b/app/models/archangel/user.rb
@@ -11,7 +11,7 @@ module Archangel
 
     typed_store :preferences, coder: JSON do |s|
       s.boolean :newsletter, default: false
-      s.datetime :preferred_at, default: Time.now
+      s.datetime :preferred_at, default: Time.now, accessor: false
     end
 
     before_validation :parameterize_username

--- a/app/views/archangel/backend/profiles/_form.html.erb
+++ b/app/views/archangel/backend/profiles/_form.html.erb
@@ -23,8 +23,10 @@
 
     <%= f.input :password, as: :password %>
     <%= f.input :password_confirmation, as: :password %>
+  </div>
 
-    <%= f.input :newsletter, as: :boolean, inline_label: Archangel.t(:subscribe_to_newsletter) %>
+  <div class="form-inputs">
+    <%= f.input :newsletter, as: :boolean %>
   </div>
 
   <div class="form-actions text-right">

--- a/app/views/archangel/backend/sites/_form.html.erb
+++ b/app/views/archangel/backend/sites/_form.html.erb
@@ -20,7 +20,13 @@
 
     <%= f.input :theme, as: :theme %>
     <%= f.input :locale, as: :language %>
+  </div>
 
+  <div class="form-inputs">
+    <%= f.input :allow_registration, as: :boolean %>
+  </div>
+
+  <div class="form-inputs">
     <div class="form-group site_metatags">
       <h3><%= Archangel.t(:metatags) %></h3>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -2,7 +2,7 @@
   <%= link_to "Log in", new_session_path(resource_name) %><br />
 <% end %>
 
-<%- if Archangel.config.allow_registration && devise_mapping.registerable? && controller_name != 'registrations' %>
+<%- if current_site.allow_registration? && devise_mapping.registerable? && controller_name != 'registrations' %>
   <%= link_to "Sign up", new_registration_path(resource_name) %><br />
 <% end %>
 

--- a/config/locales/active_record.en.yml
+++ b/config/locales/active_record.en.yml
@@ -54,6 +54,7 @@ en:
         template_id: Template
         title: Title
       archangel/site:
+        allow_registration: Allow Registration
         logo: Logo
         name: Name
         remove_logo: Remove Logo
@@ -64,6 +65,7 @@ en:
         parent_id: Parent
         partial: Partial
       archangel/user:
+        newsletter: Subscribe to newsletter
         avatar: Avatar
         email: Email
         name: Name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,7 +80,6 @@ en:
     site: Site
     slug: Slug
     sort: Sort
-    subscribe_to_newsletter: Subscribe to newsletter
     templates: Templates
     theme: Theme
     title: Title

--- a/db/migrate/20190417194514_add_settings_to_archangel_sites.rb
+++ b/db/migrate/20190417194514_add_settings_to_archangel_sites.rb
@@ -1,0 +1,5 @@
+class AddSettingsToArchangelSites < ActiveRecord::Migration[5.2]
+  def change
+    add_column :archangel_sites, :settings, :text
+  end
+end

--- a/lib/archangel/config.rb
+++ b/lib/archangel/config.rb
@@ -7,8 +7,7 @@ module Archangel
   class Config < Anyway::Config
     config_name :archangel
 
-    attr_config allow_registration: false,
-                asset_maximum_file_size: 2.megabytes,
+    attr_config asset_maximum_file_size: 2.megabytes,
                 asset_extension_whitelist: %w[gif jpeg jpg png],
                 auth_path: "account",
                 backend_path: "backend",

--- a/lib/generators/archangel/install/templates/config/archangel.yml
+++ b/lib/generators/archangel/install/templates/config/archangel.yml
@@ -4,11 +4,6 @@ default: &default
   #
   auth_path: "account"
 
-  # Allow user registrations.
-  # Default is `false`
-  #
-  allow_registration: false
-
   # Backend root path.
   # Default is "backend"
   #

--- a/spec/features/auth/registration_spec.rb
+++ b/spec/features/auth/registration_spec.rb
@@ -12,9 +12,12 @@ RSpec.feature "Auth registration", type: :feature do
   end
 
   describe "when registration is enabled" do
-    it "has additional form fields" do
-      allow(Archangel.config).to receive(:allow_registration) { true }
+    let!(:site) { create(:site, allow_registration: true) }
+    let!(:homepage) do
+      create(:page, :homepage, content: "Welcome to the homepage")
+    end
 
+    it "has additional form fields" do
       visit archangel.new_user_registration_path
 
       expect(page).to have_text "Name"
@@ -25,10 +28,6 @@ RSpec.feature "Auth registration", type: :feature do
     end
 
     it "allows successful registration" do
-      allow(Archangel.config).to receive(:allow_registration) { true }
-
-      create(:page, homepage: true, content: "Welcome to the homepage")
-
       visit archangel.new_user_registration_path
 
       fill_in "Name", with: "John Doe"


### PR DESCRIPTION
# Summary

Create settings for Site. This uses ActiveRecord::TypedStore to store the settings in the database similar to how User preferences works. The first setting being pulled over is `allow_registration`. This will turn it into a togglable Site setting instead of a static Archangel config.

## What's New

* Create migration for `archangel_sites.settings`
* Create `allow_registration` setting for Sites

## What's Changed

* Remove `Archangel.config.allow_registration`
* Make `preferred_at` setting/preference not an accessor to make it more of a creation date