### PR TITLE
Page.available?

### DIFF
--- a/app/models/archangel/page.rb
+++ b/app/models/archangel/page.rb
@@ -49,8 +49,12 @@ module Archangel
     scope :homepage, (-> { where(homepage: true) })
 
     ##
-    # Check if Page is published. Published in the past, present and future.
-    # Future publication date is also considered published.
+    # Check if Page is published.
+    #
+    # Future publication date is also considered published. This will return
+    # true if there is any published date avaialable; past and future.
+    #
+    # @see Page.available?
     #
     # @return [Boolean] if published
     #
@@ -59,20 +63,15 @@ module Archangel
     end
 
     ##
-    # Return string of publication status.
+    # Check if Page is currently available.
     #
-    # @return [String] publication status
+    # This will return true if there is a published date and it is in the past.
+    # Future publication date will return false.
     #
-    def status
-      if published?
-        if published_at > Time.now
-          "future-published"
-        else
-          "published"
-        end
-      else
-        "unpublished"
-      end
+    # @return [Boolean] if available
+    #
+    def available?
+      published? && published_at < Time.now
     end
 
     ##

--- a/app/views/archangel/backend/pages/_page.html.erb
+++ b/app/views/archangel/backend/pages/_page.html.erb
@@ -1,4 +1,4 @@
-<tr class="page-<%= page.status %>">
+<tr class="page-<%= page.published? ? "published" : "unpublished" %> page-<%= page.available? ? "available" : "unavailable" %>">
   <td>
     <%= page.title %>
 

--- a/spec/models/archangel/page_spec.rb
+++ b/spec/models/archangel/page_spec.rb
@@ -114,23 +114,23 @@ module Archangel
       end
     end
 
-    context "#status" do
-      it "returns `unpublished` for Pages not published" do
+    context ".available?" do
+      it "is available when published in the past" do
+        page = build(:page, published_at: 1.week.ago)
+
+        expect(page.available?).to be_truthy
+      end
+
+      it "is unavailable when published in the future" do
+        page = build(:page, published_at: 1.week.from_now)
+
+        expect(page.available?).to be_falsey
+      end
+
+      it "is unavailable not published" do
         page = build(:page, :unpublished)
 
-        expect(page.status).to eq("unpublished")
-      end
-
-      it "returns `future-published` for Pages published in the future" do
-        page = build(:page, :future)
-
-        expect(page.status).to eq("future-published")
-      end
-
-      it "returns `published` for Pages published in the past" do
-        page = build(:page)
-
-        expect(page.status).to eq("published")
+        expect(page.available?).to be_falsey
       end
     end
 


### PR DESCRIPTION
# Summary

Add `Page.available?` to return if the Page is published in the past as a check for availability of the Page.

Remove `Page.status` because I don't want to maintain all of the different statuses as a string. Let the View decide the status to use.

## What's New

* Add `Page.available?`

## What's Changed

* Clearer description of `Page.published?`
* Remove `Page.status`