### PR TITLE
Split frontend homepage and page

### DIFF
--- a/app/controllers/archangel/frontend/homepages_controller.rb
+++ b/app/controllers/archangel/frontend/homepages_controller.rb
@@ -11,41 +11,6 @@ module Archangel
     # Extends Archangel::Frontend/PagesController to provide functionality
     #
     class HomepagesController < PagesController
-      ##
-      # Frontend page
-      #
-      # Formats
-      #   HTML, JSON
-      #
-      # Request
-      #   GET /
-      #
-      # Response
-      #   {
-      #     "id": 123,
-      #     "title": "Homepage Title",
-      #     "permalink": "/",
-      #     "content": "</p>Content of the homepage</p>",
-      #     "homepage": true,
-      #     "published_at": "YYYY-MM-DDTHH:MM:SS.MSZ",
-      #     "created_at": "YYYY-MM-DDTHH:MM:SS.MSZ",
-      #     "updated_at": "YYYY-MM-DDTHH:MM:SS.MSZ",
-      #   }
-      #
-      def show
-        respond_to do |format|
-          format.html do
-            render inline: liquid_rendered_template_content,
-                   layout: layout_from_theme
-          end
-          format.json do
-            @page.content = liquid_rendered_content
-
-            render json: @page, layout: false
-          end
-        end
-      end
-
       protected
 
       ##
@@ -53,6 +18,15 @@ module Archangel
       #
       def set_resource
         @page = current_site.pages.published.homepage.first!
+      end
+
+      ##
+      # Override. Do not redirect. This is the homepage.
+      #
+      # @return [Boolean] false
+      #
+      def redirect_to_homepage?
+        false
       end
     end
   end

--- a/app/controllers/archangel/frontend/homepages_controller.rb
+++ b/app/controllers/archangel/frontend/homepages_controller.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Archangel
+  ##
+  # @see Archangel::FrontendController
+  #
+  module Frontend
+    ##
+    # Frontend homepages controller
+    #
+    # Extends Archangel::Frontend/PagesController to provide functionality
+    #
+    class HomepagesController < PagesController
+      ##
+      # Frontend page
+      #
+      # Formats
+      #   HTML, JSON
+      #
+      # Request
+      #   GET /
+      #
+      # Response
+      #   {
+      #     "id": 123,
+      #     "title": "Homepage Title",
+      #     "permalink": "/",
+      #     "content": "</p>Content of the homepage</p>",
+      #     "homepage": true,
+      #     "published_at": "YYYY-MM-DDTHH:MM:SS.MSZ",
+      #     "created_at": "YYYY-MM-DDTHH:MM:SS.MSZ",
+      #     "updated_at": "YYYY-MM-DDTHH:MM:SS.MSZ",
+      #   }
+      #
+      def show
+        respond_to do |format|
+          format.html do
+            render inline: liquid_rendered_template_content,
+                   layout: layout_from_theme
+          end
+          format.json do
+            @page.content = liquid_rendered_content
+
+            render json: @page, layout: false
+          end
+        end
+      end
+
+      protected
+
+      ##
+      # Find and assign resource to the view
+      #
+      def set_resource
+        @page = current_site.pages.published.homepage.first!
+      end
+    end
+  end
+end

--- a/app/controllers/archangel/frontend/pages_controller.rb
+++ b/app/controllers/archangel/frontend/pages_controller.rb
@@ -30,7 +30,7 @@ module Archangel
       #   {
       #     "id": 123,
       #     "title": "Page Title",
-      #     "permalink": "path/to/page",
+      #     "permalink": "/path/to/page",
       #     "content": "</p>Content of the page</p>",
       #     "homepage": false,
       #     "published_at": "YYYY-MM-DDTHH:MM:SS.MSZ",
@@ -39,7 +39,7 @@ module Archangel
       #   }
       #
       def show
-        return redirect_to_homepage if redirect_to_homepage?
+        return redirect_to_homepage if @page.homepage?
 
         respond_to do |format|
           format.html do
@@ -62,11 +62,7 @@ module Archangel
       def set_resource
         page_permalink = params.fetch(:permalink, nil)
 
-        @page = if page_permalink.blank?
-                  find_homepage
-                else
-                  find_page(page_permalink)
-                end
+        @page = current_site.pages.published.find_by!(permalink: page_permalink)
       end
 
       ##
@@ -91,39 +87,10 @@ module Archangel
       end
 
       ##
-      # Check to redirect to homepage root permalink
-      #
-      # @return [Boolean] redirect or not
-      #
-      def redirect_to_homepage?
-        return false unless @page
-
-        (params.fetch(:permalink, nil) == @page.permalink) && @page.homepage?
-      end
-
-      ##
       # Redirect to homepage root permalink is page is marked as the homepage
       #
       def redirect_to_homepage
         redirect_to root_path, status: :moved_permanently
-      end
-
-      ##
-      # Find the homepage
-      #
-      # @return [Object] the homepage
-      #
-      def find_homepage
-        current_site.pages.published.homepage.first!
-      end
-
-      ##
-      # Find the requested page
-      #
-      # @return [Object] the page
-      #
-      def find_page(permalink)
-        current_site.pages.published.find_by!(permalink: permalink)
       end
 
       ##

--- a/app/controllers/archangel/frontend/pages_controller.rb
+++ b/app/controllers/archangel/frontend/pages_controller.rb
@@ -39,18 +39,15 @@ module Archangel
       #   }
       #
       def show
-        return redirect_to_homepage if @page.homepage?
+        return redirect_to_homepage if redirect_to_homepage?
+
+        @page.content = liquid_rendered_template_content
 
         respond_to do |format|
           format.html do
-            render inline: liquid_rendered_template_content,
-                   layout: layout_from_theme
+            render(inline: @page.content, layout: layout_from_theme)
           end
-          format.json do
-            @page.content = liquid_rendered_content
-
-            render json: @page, layout: false
-          end
+          format.json { render(action: :show, layout: false) }
         end
       end
 
@@ -87,10 +84,19 @@ module Archangel
       end
 
       ##
+      # Check to redirect to homepage root permalink
+      #
+      # @return [Boolean] redirect or not
+      #
+      def redirect_to_homepage?
+        @page.homepage?
+      end
+
+      ##
       # Redirect to homepage root permalink is page is marked as the homepage
       #
       def redirect_to_homepage
-        redirect_to root_path, status: :moved_permanently
+        redirect_to frontend_root_path, status: :moved_permanently
       end
 
       ##

--- a/app/views/archangel/frontend/pages/show.json.jbuilder
+++ b/app/views/archangel/frontend/pages/show.json.jbuilder
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 json.page do
-  json.extract! @page, :id, :title, :path, :content
+  json.extract! @page, :id, :title, :content
+
+  json.permalink frontend_resource_path(@page)
 
   json.published_at @page.published_at.strftime("%F %T")
   json.published_at_timestamp @page.published_at.to_time.to_i

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,9 +165,9 @@ Archangel::Engine.routes.draw do
                       }
 
     # GET /
-    root to: "pages#show"
+    root to: "homepages#show"
   end
 
   # GET /
-  root to: "frontend/pages#show"
+  root to: "frontend/homepages#show"
 end

--- a/spec/controllers/archangel/frontend/homepages_controller_spec.rb
+++ b/spec/controllers/archangel/frontend/homepages_controller_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Archangel
+  module Frontend
+    RSpec.describe HomepagesController, type: :controller do
+      describe "GET #show" do
+        it "assigns the requested page as @page" do
+          page = create(:page, :homepage)
+
+          get :show
+
+          expect(response.content_type).to eq "text/html"
+          expect(assigns(:page)).to eq(page)
+        end
+
+        it "assigns the requested page as @page for JSON request" do
+          page = create(:page, :homepage)
+
+          get :show, format: :json
+
+          expect(response.content_type).to eq "application/json"
+          expect(assigns(:page)).to eq(page)
+        end
+
+        it "returns a 404 status code when page is not found" do
+          get :show
+
+          expect(response).to render_template("archangel/errors/error_404")
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/frontend/homepage_spec.rb
+++ b/spec/requests/frontend/homepage_spec.rb
@@ -4,20 +4,12 @@ require "rails_helper"
 
 RSpec.describe "Frontend - Homepage", type: :request do
   describe "with available homepage" do
-    let(:homepage) { create(:page, :homepage) }
-
-    before { homepage }
+    let!(:homepage) { create(:page, :homepage) }
 
     it "returns successfully" do
       get "/"
 
       expect(response).to be_successful
-    end
-
-    it "redirects to frontend_root_path when homepage permalink requested" do
-      get "/#{homepage.permalink}"
-
-      expect(response).to redirect_to("/")
     end
   end
 
@@ -48,13 +40,10 @@ RSpec.describe "Frontend - Homepage", type: :request do
   end
 
   describe "with multiple homepages" do
-    let(:first_homepage) { create(:page, :homepage, content: "First") }
-    let(:second_homepage) { create(:page, content: "Second") }
+    let!(:first_homepage) { create(:page, :homepage, content: "First") }
+    let!(:second_homepage) { create(:page, content: "Second") }
 
     before do
-      first_homepage
-      second_homepage
-
       second_homepage.update_column(:homepage, true)
     end
 

--- a/spec/requests/frontend/page_spec.rb
+++ b/spec/requests/frontend/page_spec.rb
@@ -4,14 +4,22 @@ require "rails_helper"
 
 RSpec.describe "Frontend - Page", type: :request do
   describe "with available page" do
-    let(:resource) { create(:page, slug: "foo") }
-
-    before { resource }
+    let!(:resource) { create(:page, slug: "foo") }
 
     it "returns successfully" do
       get "/foo"
 
       expect(response).to be_successful
+    end
+  end
+
+  describe "with homepage" do
+    let!(:resource) { create(:page, :homepage, slug: "foo") }
+
+    it "redirects to root path" do
+      get "/foo"
+
+      expect(response).to redirect_to("/")
     end
   end
 

--- a/spec/requests/frontend/page_spec.rb
+++ b/spec/requests/frontend/page_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Frontend - Page", type: :request do
     it "returns 404 when page is future published" do
       create(:page, :future, slug: "foo")
 
-      get "/"
+      get "/foo"
 
       expect(response).to be_not_found
     end
@@ -35,7 +35,7 @@ RSpec.describe "Frontend - Page", type: :request do
     it "returns 404 when page is deleted" do
       create(:page, :deleted, slug: "foo")
 
-      get "/"
+      get "/foo"
 
       expect(response).to be_not_found
     end


### PR DESCRIPTION
# Summary

Separate the homepage from other pages. Even though they are the same resource, the homepage needs to be treated slightly different.

This also makes it easier for extensions to override the homepage functionality.

## What's New

* Moved all homepage functionality removed from `PagesController` into `HomepagesController`

## What's Changed

* Point the routes at the new `HomepagesController` resource for the root routes
* Remove all homepage checks from `PagesController`