### PR TITLE
Add timecop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ end
 
 group :test do
   gem "simplecov", "~> 0.16", require: false
+  gem "timecop", "~> 0.9", require: false
 
   gem "capybara", "~> 3.8"
   gem "database_cleaner", "~> 1.7"

--- a/spec/support/timecop.rb
+++ b/spec/support/timecop.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "timecop"
+
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+
+  config.before do
+    Timecop.freeze
+  end
+
+  config.after do
+    Timecop.return
+  end
+end


### PR DESCRIPTION
# Summary

Every once in a while tests fail because tests are off by a second and can't compare dates properly. Add [`timecop`](https://github.com/travisjeffery/timecop) so that time gets paused for tests.

## What's New

* Add `timecop` gem 
* Add Rspec config to pause time while each test is running

## What's Changed

* Nothing