### PR TITLE
Add json-schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :development, :test do
 end
 
 group :test do
+  gem "json-schema", "~> 2.8", require: false
   gem "simplecov", "~> 0.16", require: false
 
   gem "capybara", "~> 3.8"

--- a/app/controllers/archangel/frontend/pages_controller.rb
+++ b/app/controllers/archangel/frontend/pages_controller.rb
@@ -47,7 +47,9 @@ module Archangel
           format.html do
             render(inline: @page.content, layout: layout_from_theme)
           end
-          format.json { render(action: :show, layout: false) }
+          format.json do
+            render(template: "archangel/frontend/pages/show", layout: false)
+          end
         end
       end
 

--- a/app/views/archangel/frontend/pages/show.json.jbuilder
+++ b/app/views/archangel/frontend/pages/show.json.jbuilder
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 json.page do
-  json.extract! @page, :id, :title, :content
+  json.extract! @page, :id, :title, :homepage, :content
 
   json.permalink frontend_resource_path(@page)
 
-  json.published_at @page.published_at.strftime("%F %T")
-  json.published_at_timestamp @page.published_at.to_time.to_i
+  json.published_at @page.published_at
 end

--- a/spec/requests/frontend/homepage_spec.rb
+++ b/spec/requests/frontend/homepage_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe "Frontend - Homepage", type: :request do
     end
   end
 
+  describe "with available page as JSON" do
+    let!(:resource) { create(:page, :homepage) }
+
+    it "returns successfully" do
+      get "/", headers: { accept: "application/json" }
+
+      expect(response).to match_response_schema("frontend/pages/show")
+    end
+  end
+
   describe "with unavailable homepage" do
     it "returns 404 when homepage is unpublished" do
       create(:page, :homepage, :unpublished)
@@ -59,6 +69,15 @@ RSpec.describe "Frontend - Homepage", type: :request do
       get "/"
 
       expect(response).to be_not_found
+    end
+  end
+
+  describe "with available page as JSON" do
+    it "returns successfully" do
+      get "/", headers: { accept: "application/json" }
+
+      expect(response).to be_not_found
+      expect(response).to match_response_schema("frontend/errors/not_found")
     end
   end
 end

--- a/spec/requests/frontend/page_spec.rb
+++ b/spec/requests/frontend/page_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe "Frontend - Page", type: :request do
     end
   end
 
+  describe "with available page as JSON" do
+    let!(:resource) { create(:page, slug: "foo") }
+
+    it "returns successfully" do
+      get "/foo", headers: { accept: "application/json" }
+
+      expect(response).to match_response_schema("frontend/pages/show")
+    end
+  end
+
   describe "with homepage" do
     let!(:resource) { create(:page, :homepage, slug: "foo") }
 
@@ -54,6 +64,15 @@ RSpec.describe "Frontend - Page", type: :request do
       get "/broken"
 
       expect(response).to be_not_found
+    end
+  end
+
+  describe "with available page as JSON" do
+    it "returns successfully" do
+      get "/broken", headers: { accept: "application/json" }
+
+      expect(response).to be_not_found
+      expect(response).to match_response_schema("frontend/errors/not_found")
     end
   end
 end

--- a/spec/support/json_schema_matcher.rb
+++ b/spec/support/json_schema_matcher.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "json-schema"
+
+RSpec::Matchers.define :match_response_schema do |schema|
+  match do |response|
+    schema_directory = "#{Dir.pwd}/spec/support/schemas"
+    schema_path = "#{schema_directory}/#{schema}.json"
+
+    JSON::Validator.validate!(schema_path, response.body, strict: true)
+  end
+end

--- a/spec/support/schemas/frontend/errors/not_found.json
+++ b/spec/support/schemas/frontend/errors/not_found.json
@@ -1,0 +1,11 @@
+{
+  "type" : "object",
+  "required" : [
+    "status",
+    "error"
+  ],
+  "properties" : {
+    "status" : { "type" : "integer" },
+    "error" : { "type" : "string" }
+  }
+}

--- a/spec/support/schemas/frontend/pages/show.json
+++ b/spec/support/schemas/frontend/pages/show.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "required": ["page"],
+  "properties": {
+    "page" : {
+      "type" : "object",
+      "required" : [
+        "id",
+        "title",
+        "homepage",
+        "content",
+        "permalink",
+        "published_at"
+      ],
+      "properties" : {
+        "id" : { "type" : "integer" },
+        "title" : { "type" : "string" },
+        "homepage" : { "type" : "boolean" },
+        "content" : { "type" : "string" },
+        "permalink" : { "type" : "string" },
+        "published_at" : { "type" : "string", "format": "date-time" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Summary

Add [`json-schema`](https://github.com/ruby-json-schema/json-schema) to test JSON response schemas.

## What's New

* Add `json-schema` gem
* Added JSON schema and tests for frontend pages
* Added JSON schema and tests for frontend 404 errors

## What's Changed

Nothing