### PR TITLE
Remove Entry.status

### DIFF
--- a/app/controllers/archangel/backend/entries_controller.rb
+++ b/app/controllers/archangel/backend/entries_controller.rb
@@ -57,7 +57,7 @@ module Archangel
         fields = @collection.fields.map { |record| record[:slug].to_sym }
 
         [
-          :available_at,
+          :published_at,
           value: fields
         ]
       end

--- a/app/models/archangel/entry.rb
+++ b/app/models/archangel/entry.rb
@@ -17,33 +17,44 @@ module Archangel
 
     belongs_to :collection
 
+    scope :accessible, (lambda do
+      available.where("available_at <= ?", Time.now)
+    end)
+
+    scope :available, (lambda do
+      where.not(available_at: nil)
+    end)
+
+    scope :unavailable, (lambda do
+      where("available_at IS NULL OR available_at > ?", Time.now)
+    end)
+
     default_scope { order(position: :asc) }
 
     ##
-    # Check if Entry is available. Available in the past, present and future.
-    # Future availability date is also considered available.
+    # Check if Entry is currently accessible.
+    #
+    # This will return true if there is a published date and it is in the past.
+    # Future publication date will return false.
+    #
+    # @return [Boolean] if accessible
+    #
+    def accessible?
+      available? && available_at < Time.now
+    end
+
+    ##
+    # Check if Entry is available.
+    #
+    # Future publication date is also considered available. This will return
+    # true if there is any available date avaialable; past and future.
+    #
+    # @see Entry.accessible?
     #
     # @return [Boolean] if available
     #
     def available?
       available_at.present?
-    end
-
-    ##
-    # Return string of availability status.
-    #
-    # @return [String] available status
-    #
-    def status
-      if available?
-        if available_at > Time.now
-          "future-available"
-        else
-          "available"
-        end
-      else
-        "unavailable"
-      end
     end
   end
 end

--- a/app/models/archangel/entry.rb
+++ b/app/models/archangel/entry.rb
@@ -12,49 +12,49 @@ module Archangel
     acts_as_list scope: :collection_id, top_of_list: 0, add_new_at: :top
 
     validates :collection_id, presence: true
-    validates :available_at, allow_blank: true, date: true
+    validates :published_at, allow_blank: true, date: true
     validates :value, presence: true
 
     belongs_to :collection
 
-    scope :accessible, (lambda do
-      available.where("available_at <= ?", Time.now)
-    end)
-
     scope :available, (lambda do
-      where.not(available_at: nil)
+      published.where("published_at <= ?", Time.now)
     end)
 
-    scope :unavailable, (lambda do
-      where("available_at IS NULL OR available_at > ?", Time.now)
+    scope :published, (lambda do
+      where.not(published_at: nil)
+    end)
+
+    scope :unpublished, (lambda do
+      where("published_at IS NULL OR published_at > ?", Time.now)
     end)
 
     default_scope { order(position: :asc) }
 
     ##
-    # Check if Entry is currently accessible.
+    # Check if Entry is currently available.
     #
     # This will return true if there is a published date and it is in the past.
     # Future publication date will return false.
     #
-    # @return [Boolean] if accessible
-    #
-    def accessible?
-      available? && available_at < Time.now
-    end
-
-    ##
-    # Check if Entry is available.
-    #
-    # Future publication date is also considered available. This will return
-    # true if there is any available date avaialable; past and future.
-    #
-    # @see Entry.accessible?
-    #
     # @return [Boolean] if available
     #
     def available?
-      available_at.present?
+      published? && published_at < Time.now
+    end
+
+    ##
+    # Check if Entry is published.
+    #
+    # Future publication date is also considered published. This will return
+    # true if there is any published date avaialable; past and future.
+    #
+    # @see Entry.available?
+    #
+    # @return [Boolean] if published
+    #
+    def published?
+      published_at.present?
     end
   end
 end

--- a/app/views/archangel/backend/entries/_entry.html.erb
+++ b/app/views/archangel/backend/entries/_entry.html.erb
@@ -1,10 +1,10 @@
-<tr class="entry-<%= entry.available? ? "available" : "unavailable" %> entry-<%= entry.accessible? ? "accessible" : "inaccessible" %>"
+<tr class="entry-<%= entry.published? ? "published" : "unpublished" %> entry-<%= entry.available? ? "available" : "unavailable" %>"
     data-id="<%= entry.id %>">
   <td class="text-center"><%= Archangel.t(:sort) %></td>
   <% fields.each do |field| %>
     <td><%= entry.value[field] %></td>
   <% end %>
-  <td><%= entry.available_at %></td>
+  <td><%= entry.published_at %></td>
   <td class="actions text-right">
     <%= link_to(Archangel.t(:show), backend_collection_entry_path(entry.collection, entry), class: "btn btn-info btn-sm") %>
     <%= link_to(Archangel.t(:edit), edit_backend_collection_entry_path(entry.collection, entry), class: "btn btn-warning btn-sm") %>

--- a/app/views/archangel/backend/entries/_entry.html.erb
+++ b/app/views/archangel/backend/entries/_entry.html.erb
@@ -1,4 +1,5 @@
-<tr class="entry-<%= entry.status %>" data-id="<%= entry.id %>">
+<tr class="entry-<%= entry.available? ? "available" : "unavailable" %> entry-<%= entry.accessible? ? "accessible" : "inaccessible" %>"
+    data-id="<%= entry.id %>">
   <td class="text-center"><%= Archangel.t(:sort) %></td>
   <% fields.each do |field| %>
     <td><%= entry.value[field] %></td>

--- a/app/views/archangel/backend/entries/_form.html.erb
+++ b/app/views/archangel/backend/entries/_form.html.erb
@@ -16,7 +16,7 @@
       <% end %>
     <% end %>
 
-    <%= f.input :available_at, as: :date_time_picker %>
+    <%= f.input :published_at, as: :date_time_picker %>
   </div>
 
   <div class="form-actions text-right">

--- a/app/views/archangel/backend/entries/index.html.erb
+++ b/app/views/archangel/backend/entries/index.html.erb
@@ -27,7 +27,7 @@
                     <% fields.each do |field| %>
                       <th scope="col"><%= field.titleize %></th>
                     <% end %>
-                    <th scope="col"><%= Archangel.t(:available_at) %></th>
+                    <th scope="col"><%= Archangel.t(:published_at) %></th>
                     <th class="actions text-right" scope="col"><%= Archangel.t(:actions) %></th>
                   </tr>
                 </thead>

--- a/config/locales/active_record.en.yml
+++ b/config/locales/active_record.en.yml
@@ -36,6 +36,8 @@ en:
       archangel/collection:
         name: Name
         slug: Slug
+      archangel/entry:
+        published_at: Published At
       archangel/field:
         classification: Classification
         label: Label

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,7 +7,6 @@ en:
     are_you_sure: Are you sure?
     archangel: Archangel
     assets: Assets
-    available_at: Available At
     avatar: Avatar
     back: Back
     classification:

--- a/db/migrate/20190421165525_rename_archangel_entries_available_at_to_published_at.rb
+++ b/db/migrate/20190421165525_rename_archangel_entries_available_at_to_published_at.rb
@@ -1,0 +1,5 @@
+class RenameArchangelEntriesAvailableAtToPublishedAt < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :archangel_entries, :available_at, :published_at
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -126,5 +126,5 @@ end
 # Entry
 collection.entries.find_or_create_by(collection: collection) do |item|
   item.value = { field1: "Value for field 1" }
-  item.available_at = Time.now
+  item.published_at = Time.now
 end

--- a/lib/archangel/liquid/tags/collection_tag.rb
+++ b/lib/archangel/liquid/tags/collection_tag.rb
@@ -96,7 +96,7 @@ module Archangel
           collection = site.collections.find_by!(slug: slug)
 
           site.entries
-              .accessible
+              .available
               .where(collection: collection)
               .page(attributes.fetch(:offset, 1))
               .per(attributes.fetch(:limit, 12))

--- a/lib/archangel/liquid/tags/collection_tag.rb
+++ b/lib/archangel/liquid/tags/collection_tag.rb
@@ -96,6 +96,7 @@ module Archangel
           collection = site.collections.find_by!(slug: slug)
 
           site.entries
+              .accessible
               .where(collection: collection)
               .page(attributes.fetch(:offset, 1))
               .per(attributes.fetch(:limit, 12))

--- a/lib/archangel/liquid/tags/collectionfor_tag.rb
+++ b/lib/archangel/liquid/tags/collectionfor_tag.rb
@@ -71,7 +71,7 @@ module Archangel
           limit = 12 if limit.blank?
 
           site.entries
-              .accessible
+              .available
               .where(collection: collection)
               .page(offset).per(limit)
               .map(&:attributes)

--- a/lib/archangel/liquid/tags/collectionfor_tag.rb
+++ b/lib/archangel/liquid/tags/collectionfor_tag.rb
@@ -71,9 +71,9 @@ module Archangel
           limit = 12 if limit.blank?
 
           site.entries
+              .accessible
               .where(collection: collection)
-              .page(offset)
-              .per(limit)
+              .page(offset).per(limit)
               .map(&:attributes)
         rescue StandardError
           []

--- a/lib/archangel/testing_support/factories/archangel_entries.rb
+++ b/lib/archangel/testing_support/factories/archangel_entries.rb
@@ -4,18 +4,18 @@ FactoryBot.define do
   factory :entry, class: "Archangel::Entry" do
     collection
     value { ActiveSupport::JSON.encode(title: "Title", content: "Content") }
-    available_at { Time.current }
+    published_at { Time.current }
 
     trait :deleted do
       deleted_at { Time.current }
     end
 
-    trait :unavailable do
-      available_at { nil }
+    trait :unpublished do
+      published_at { nil }
     end
 
     trait :future do
-      available_at { 1.week.from_now }
+      published_at { 1.week.from_now }
     end
   end
 end

--- a/spec/controllers/archangel/backend/entries_controller_spec.rb
+++ b/spec/controllers/archangel/backend/entries_controller_spec.rb
@@ -61,7 +61,7 @@ module Archangel
               value: {
                 slug: "new-collection-entry"
               },
-              available_at: Time.current
+              published_at: Time.current
             }
           end
 

--- a/spec/models/archangel/entry_spec.rb
+++ b/spec/models/archangel/entry_spec.rb
@@ -19,6 +19,70 @@ module Archangel
       it { is_expected.to belong_to(:collection) }
     end
 
+    context ".accessible?" do
+      it "is accessible" do
+        entry = build(:entry)
+
+        expect(entry.accessible?).to be_truthy
+      end
+
+      it "is not accessible in the future" do
+        entry = build(:entry, available_at: 1.week.from_now)
+
+        expect(entry.accessible?).to be_falsey
+      end
+
+      it "is not accessible" do
+        entry = build(:entry, :unavailable)
+
+        expect(entry.accessible?).to be_falsey
+      end
+    end
+
+    context "scopes" do
+      context ".accessible" do
+        it "returns all where available_at <= now" do
+          entry = create(:entry)
+
+          expect(described_class.accessible.first).to eq(entry)
+        end
+
+        it "returns all where available_at <= now in the future" do
+          entry = create(:entry, :future)
+
+          expect(described_class.accessible.first).to_not eq(entry)
+        end
+      end
+
+      context ".available" do
+        it "returns all where available_at <= now" do
+          entry = create(:entry)
+
+          expect(described_class.available.first).to eq(entry)
+        end
+
+        it "returns all where available_at <= now in the future" do
+          entry = create(:entry, :future)
+
+          expect(described_class.available.first).to eq(entry)
+        end
+      end
+
+      context ".unavailable" do
+        it "returns all where available_at is nil" do
+          entry = create(:entry, :unavailable)
+
+          expect(described_class.unavailable.first).to eq(entry)
+        end
+
+        it "returns all where available_at is > now" do
+          entry = create(:entry, :future)
+
+          expect(described_class.unavailable.first).to eq(entry)
+        end
+      end
+    end
+
     context ".available?" do
       it "is available" do
         entry = build(:entry)
@@ -36,26 +100,6 @@ module Archangel
         entry = build(:entry, :unavailable)
 
         expect(entry.available?).to be_falsey
-      end
-    end
-
-    context "#status" do
-      it "returns `unavailable` for Entries not available" do
-        entry = build(:entry, :unavailable)
-
-        expect(entry.status).to eq("unavailable")
-      end
-
-      it "returns `future-available` for Entries available in the future" do
-        entry = build(:entry, :future)
-
-        expect(entry.status).to eq("future-available")
-      end
-
-      it "returns `available` for Entries available in the past" do
-        entry = build(:entry)
-
-        expect(entry.status).to eq("available")
       end
     end
   end

--- a/spec/models/archangel/entry_spec.rb
+++ b/spec/models/archangel/entry_spec.rb
@@ -8,77 +8,57 @@ module Archangel
       it { is_expected.to validate_presence_of(:collection_id) }
       it { is_expected.to validate_presence_of(:value) }
 
-      it { is_expected.to allow_value(nil).for(:available_at) }
-      it { is_expected.to allow_value("").for(:available_at) }
-      it { is_expected.to allow_value(Time.current).for(:available_at) }
+      it { is_expected.to allow_value(nil).for(:published_at) }
+      it { is_expected.to allow_value("").for(:published_at) }
+      it { is_expected.to allow_value(Time.current).for(:published_at) }
 
-      it { is_expected.to_not allow_value("invalid").for(:available_at) }
+      it { is_expected.to_not allow_value("invalid").for(:published_at) }
     end
 
     context "associations" do
       it { is_expected.to belong_to(:collection) }
     end
 
-    context ".accessible?" do
-      it "is accessible" do
-        entry = build(:entry)
-
-        expect(entry.accessible?).to be_truthy
-      end
-
-      it "is not accessible in the future" do
-        entry = build(:entry, available_at: 1.week.from_now)
-
-        expect(entry.accessible?).to be_falsey
-      end
-
-      it "is not accessible" do
-        entry = build(:entry, :unavailable)
-
-        expect(entry.accessible?).to be_falsey
-      end
-    end
-
     context "scopes" do
-      context ".accessible" do
-        it "returns all where available_at <= now" do
+      context ".available" do
+        it "returns all where published_at <= now" do
           entry = create(:entry)
 
-          expect(described_class.accessible.first).to eq(entry)
+          expect(described_class.available.first).to eq(entry)
         end
 
-        it "returns all where available_at <= now in the future" do
+        it "returns all where published_at <= now in the future" do
           entry = create(:entry, :future)
 
-          expect(described_class.accessible.first).to_not eq(entry)
+          expect(described_class.available.first).to_not eq(entry)
         end
       end
 
       context ".available" do
-        it "returns all where available_at <= now" do
+        it "returns all where published_at <= now" do
           entry = create(:entry)
 
           expect(described_class.available.first).to eq(entry)
         end
 
-        it "returns all where available_at <= now in the future" do
+        it "returns all where published_at <= now not in the future" do
           entry = create(:entry, :future)
 
-          expect(described_class.available.first).to eq(entry)
+          expect(described_class.available.first).to_not eq(entry)
         end
       end
 
-      context ".unavailable" do
+      context ".unpublished" do
         it "returns all where available_at is nil" do
-          entry = create(:entry, :unavailable)
+          entry = create(:entry, :unpublished)
 
-          expect(described_class.unavailable.first).to eq(entry)
+          expect(described_class.unpublished.first).to eq(entry)
         end
 
         it "returns all where available_at is > now" do
           entry = create(:entry, :future)
 
-          expect(described_class.unavailable.first).to eq(entry)
+          expect(described_class.unpublished.first).to eq(entry)
         end
       end
     end
@@ -90,16 +70,36 @@ module Archangel
         expect(entry.available?).to be_truthy
       end
 
-      it "is available in the future" do
-        entry = build(:entry, available_at: 1.week.from_now)
+      it "is not available in the future" do
+        entry = build(:entry, published_at: 1.week.from_now)
 
-        expect(entry.available?).to be_truthy
+        expect(entry.available?).to be_falsey
       end
 
       it "is not available" do
-        entry = build(:entry, :unavailable)
+        entry = build(:entry, :unpublished)
 
         expect(entry.available?).to be_falsey
+      end
+    end
+
+    context ".published?" do
+      it "is published" do
+        entry = build(:entry)
+
+        expect(entry.published?).to be_truthy
+      end
+
+      it "is published in the future" do
+        entry = build(:entry, published_at: 1.week.from_now)
+
+        expect(entry.published?).to be_truthy
+      end
+
+      it "is not published" do
+        entry = build(:entry, :unpublished)
+
+        expect(entry.published?).to be_falsey
       end
     end
   end


### PR DESCRIPTION
# Summary

Similar to PR #22. Add `Entry.available?` to return if the Entry is available in the past as a check for published date of the Entry.

Remove `Entry.status` because I don't want to maintain all of the different statuses as a string. Let the View decide the status to use.

## What's New

* Add migration to rename `archangel_entries.available_at` to `archangel_entries.published_at`
* Add `Entry.available?`
* Add `Entry.published?`

## What's Changed

* Allow Liquid tags to pull only available Entries