### PR TITLE
Model PublishableConcern

### DIFF
--- a/app/models/archangel/entry.rb
+++ b/app/models/archangel/entry.rb
@@ -5,6 +5,8 @@ module Archangel
   # Entry model
   #
   class Entry < ApplicationRecord
+    include Archangel::Models::PublishableConcern
+
     acts_as_paranoid
 
     serialize :value, JSON
@@ -12,49 +14,10 @@ module Archangel
     acts_as_list scope: :collection_id, top_of_list: 0, add_new_at: :top
 
     validates :collection_id, presence: true
-    validates :published_at, allow_blank: true, date: true
     validates :value, presence: true
 
     belongs_to :collection
 
-    scope :available, (lambda do
-      published.where("published_at <= ?", Time.now)
-    end)
-
-    scope :published, (lambda do
-      where.not(published_at: nil)
-    end)
-
-    scope :unpublished, (lambda do
-      where("published_at IS NULL OR published_at > ?", Time.now)
-    end)
-
     default_scope { order(position: :asc) }
-
-    ##
-    # Check if Entry is currently available.
-    #
-    # This will return true if there is a published date and it is in the past.
-    # Future publication date will return false.
-    #
-    # @return [Boolean] if available
-    #
-    def available?
-      published? && published_at <= Time.now
-    end
-
-    ##
-    # Check if Entry is published.
-    #
-    # Future publication date is also considered published. This will return
-    # true if there is any published date avaialable; past and future.
-    #
-    # @see Entry.available?
-    #
-    # @return [Boolean] if published
-    #
-    def published?
-      published_at.present?
-    end
   end
 end

--- a/app/models/archangel/page.rb
+++ b/app/models/archangel/page.rb
@@ -5,6 +5,8 @@ module Archangel
   # Page model
   #
   class Page < ApplicationRecord
+    include Archangel::Models::PublishableConcern
+
     extend ActsAsTree::TreeView
 
     acts_as_tree order: :title
@@ -21,7 +23,6 @@ module Archangel
     validates :content, presence: true
     validates :homepage, inclusion: { in: [true, false] }
     validates :permalink, uniqueness: { scope: :site_id }
-    validates :published_at, allow_blank: true, date: true
     validates :slug, presence: true,
                      uniqueness: { scope: %i[parent_id site_id] }
     validates :title, presence: true
@@ -38,45 +39,7 @@ module Archangel
     accepts_nested_attributes_for :metatags, reject_if: :all_blank,
                                              allow_destroy: true
 
-    scope :available, (lambda do
-      published.where("published_at <= ?", Time.now)
-    end)
-
     scope :homepage, (-> { where(homepage: true) })
-
-    scope :published, (lambda do
-      where.not(published_at: nil)
-    end)
-
-    scope :unpublished, (lambda do
-      where("published_at IS NULL OR published_at > ?", Time.now)
-    end)
-
-    ##
-    # Check if Page is published.
-    #
-    # Future publication date is also considered published. This will return
-    # true if there is any published date avaialable; past and future.
-    #
-    # @see Page.available?
-    #
-    # @return [Boolean] if published
-    #
-    def published?
-      published_at.present?
-    end
-
-    ##
-    # Check if Page is currently available.
-    #
-    # This will return true if there is a published date and it is in the past.
-    # Future publication date will return false.
-    #
-    # @return [Boolean] if available
-    #
-    def available?
-      published? && published_at <= Time.now
-    end
 
     ##
     # Liquid object for Page

--- a/app/models/concerns/archangel/models/publishable_concern.rb
+++ b/app/models/concerns/archangel/models/publishable_concern.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Archangel
+  ##
+  # Model concerns
+  #
+  module Models
+    ##
+    # Model publish concern
+    #
+    module PublishableConcern
+      extend ActiveSupport::Concern
+
+      included do
+        validates :published_at, allow_blank: true, date: true
+
+        scope :available, (lambda do
+          published.where("published_at <= ?", Time.now)
+        end)
+
+        scope :published, (lambda do
+          where.not(published_at: nil)
+        end)
+
+        scope :unpublished, (lambda do
+          where("published_at IS NULL OR published_at > ?", Time.now)
+        end)
+      end
+
+      ##
+      # Check if resource is published.
+      #
+      # Future publication date is also considered published. This will return
+      # true if there is any published date avaialable; past and future.
+      #
+      # @see resource.available?
+      #
+      # @return [Boolean] if published
+      #
+      def published?
+        published_at.present?
+      end
+
+      ##
+      # Check if resource is currently available.
+      #
+      # This will return true if there is a published date and it is in the
+      # past. Future publication date will return false.
+      #
+      # @return [Boolean] if available
+      #
+      def available?
+        published? && published_at <= Time.now
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Summary

Introduce `PublishableConcern` for models to manage "Published At" dates, scopes and checks.

This is being turned into a concern so future features can re-use the same resources.

## What's New

* Move `published_at` column validate to `PublishableConcern`
* Move `available`, `published` and `unpublished` scopes to `PublishableConcern`
* Move `published?` and `available?` checks to `PublishableConcern`

## What's Changed

* Add `PublishableConcern` to Entry model
* Add `PublishableConcern` to Page model
