### PR TITLE
Site.homepage_redirect setting

### DIFF
--- a/app/controllers/archangel/application_controller.rb
+++ b/app/controllers/archangel/application_controller.rb
@@ -113,7 +113,7 @@ module Archangel
     # @param _exception [Object] error object
     # @return [String] response
     #
-    def render_error(path, status, _exception)
+    def render_error(path, status, _exception = nil)
       respond_to do |format|
         format.html { render(template: path, status: status) }
         format.json { render(template: path, status: status, layout: false) }

--- a/app/controllers/archangel/backend/sites_controller.rb
+++ b/app/controllers/archangel/backend/sites_controller.rb
@@ -136,7 +136,7 @@ module Archangel
       def permitted_attributes
         [
           :locale, :logo, :name, :remove_logo, :theme,
-          :allow_registration,
+          :allow_registration, :homepage_redirect,
           metatags_attributes: %i[id _destroy name content]
         ]
       end

--- a/app/controllers/archangel/frontend/pages_controller.rb
+++ b/app/controllers/archangel/frontend/pages_controller.rb
@@ -39,7 +39,7 @@ module Archangel
       #   }
       #
       def show
-        return redirect_to_homepage if redirect_to_homepage?
+        return render_or_redirect_to_homepage if redirect_to_homepage?
 
         respond_to do |format|
           format.html do
@@ -87,6 +87,12 @@ module Archangel
 
         { image_src: current_site.logo.url }.merge(meta_tags)
                                             .merge(title: @page.title)
+      end
+
+      def render_or_redirect_to_homepage
+        return redirect_to_homepage if current_site.homepage_redirect?
+
+        render_error("archangel/errors/error_404", :not_found)
       end
 
       ##

--- a/app/models/archangel/site.rb
+++ b/app/models/archangel/site.rb
@@ -11,6 +11,7 @@ module Archangel
 
     typed_store :settings, coder: JSON do |s|
       s.boolean :allow_registration, default: false
+      s.boolean :homepage_redirect, default: false
       s.datetime :preferred_at, default: Time.now, accessor: false
     end
 
@@ -22,6 +23,7 @@ module Archangel
     validates :theme, inclusion: { in: Archangel.themes }, allow_blank: true
 
     validates :allow_registration, inclusion: { in: [true, false] }
+    validates :homepage_redirect, inclusion: { in: [true, false] }
 
     has_many :assets
     has_many :collections

--- a/app/views/archangel/backend/sites/_form.html.erb
+++ b/app/views/archangel/backend/sites/_form.html.erb
@@ -24,6 +24,7 @@
 
   <div class="form-inputs">
     <%= f.input :allow_registration, as: :boolean %>
+    <%= f.input :homepage_redirect, as: :boolean %>
   </div>
 
   <div class="form-inputs">

--- a/spec/requests/frontend/html/nested_page_spec.rb
+++ b/spec/requests/frontend/html/nested_page_spec.rb
@@ -26,14 +26,26 @@ RSpec.describe "Frontend - Nested Page (HTML)", type: :request do
   end
 
   describe "with homepage" do
-    it "redirects to root path" do
-      parent_a = create(:page, slug: "foo")
-      create(:page, :homepage, parent: parent_a, slug: "bar")
+    it "redirects to root path when Site homepage_redirect is true" do
+      site = create(:site, homepage_redirect: true)
+      parent_a = create(:page, site: site, slug: "foo")
+      create(:page, :homepage, site: site, parent: parent_a, slug: "bar")
 
       get "/foo/bar"
 
       expect(response).to redirect_to("/")
       expect(response).to have_http_status(:moved_permanently)
+    end
+
+    it "throws 404 when Site homepage_redirect is false" do
+      site = create(:site, homepage_redirect: false)
+      parent_a = create(:page, site: site, slug: "foo")
+      create(:page, :homepage, site: site, parent: parent_a, slug: "bar")
+
+      get "/foo/bar"
+
+      expect(response.content_type).to eq("text/html")
+      expect(response).to have_http_status(:not_found)
     end
   end
 

--- a/spec/requests/frontend/html/page_spec.rb
+++ b/spec/requests/frontend/html/page_spec.rb
@@ -24,13 +24,24 @@ RSpec.describe "Frontend - Root Page (HTML)", type: :request do
   end
 
   describe "with homepage" do
-    it "redirects to root path" do
-      create(:page, :homepage, slug: "foo")
+    it "redirects to root path when Site homepage_redirect is true" do
+      site = create(:site, homepage_redirect: true)
+      create(:page, :homepage, site: site, slug: "foo")
 
       get "/foo"
 
       expect(response).to redirect_to("/")
       expect(response).to have_http_status(:moved_permanently)
+    end
+
+    it "throws 404 when Site homepage_redirect is false" do
+      site = create(:site, homepage_redirect: false)
+      create(:page, :homepage, site: site, slug: "foo")
+
+      get "/foo"
+
+      expect(response.content_type).to eq("text/html")
+      expect(response).to have_http_status(:not_found)
     end
   end
 

--- a/spec/requests/frontend/json/nested_page_spec.rb
+++ b/spec/requests/frontend/json/nested_page_spec.rb
@@ -37,14 +37,26 @@ RSpec.describe "Frontend - Nested Page (JSON)", type: :request do
   end
 
   describe "with homepage" do
-    it "redirects to root path" do
-      parent_a = create(:page, slug: "foo")
-      create(:page, :homepage, parent: parent_a, slug: "bar")
+    it "redirects to root path when Site homepage_redirect is true" do
+      site = create(:site, homepage_redirect: true)
+      parent_a = create(:page, site: site, slug: "foo")
+      create(:page, :homepage, site: site, parent: parent_a, slug: "bar")
 
       get "/foo/bar", headers: { accept: "application/json" }
 
       expect(response).to redirect_to("/")
       expect(response).to have_http_status(:moved_permanently)
+    end
+
+    it "throws 404 when Site homepage_redirect is false" do
+      site = create(:site, homepage_redirect: false)
+      parent_a = create(:page, site: site, slug: "foo")
+      create(:page, :homepage, site: site, parent: parent_a, slug: "bar")
+
+      get "/foo/bar", headers: { accept: "application/json" }
+
+      expect(response.content_type).to eq("application/json")
+      expect(response).to have_http_status(:not_found)
     end
   end
 

--- a/spec/requests/frontend/json/page_spec.rb
+++ b/spec/requests/frontend/json/page_spec.rb
@@ -34,13 +34,24 @@ RSpec.describe "Frontend - Root Page (JSON)", type: :request do
   end
 
   describe "with homepage" do
-    it "redirects to root path" do
-      create(:page, :homepage, slug: "foo")
+    it "redirects to root path when Site homepage_redirect is true" do
+      site = create(:site, homepage_redirect: true)
+      create(:page, :homepage, site: site, slug: "foo")
 
       get "/foo", headers: { accept: "application/json" }
 
       expect(response).to redirect_to("/")
       expect(response).to have_http_status(:moved_permanently)
+    end
+
+    it "throws 404 when Site homepage_redirect is false" do
+      site = create(:site, homepage_redirect: false)
+      create(:page, :homepage, site: site, slug: "foo")
+
+      get "/foo", headers: { accept: "application/json" }
+
+      expect(response.content_type).to eq("application/json")
+      expect(response).to have_http_status(:not_found)
     end
   end
 


### PR DESCRIPTION
# Summary

When the homepage permalink is requested, allow a Site configuration of `homepage_redirect` determine if it should redirect to the root path or render a 404 error.

## What's New

* Add `homepage_redirect` setting for Site

## What's Changed

Nothing